### PR TITLE
Show connector identifier in sidebar

### DIFF
--- a/apps/connectors-docs/app/connectors/[connector]/[version]/[creator]/[language]/[implementation]/page.tsx
+++ b/apps/connectors-docs/app/connectors/[connector]/[version]/[creator]/[language]/[implementation]/page.tsx
@@ -223,6 +223,7 @@ export default async function ConnectorImplementationPage({
           <ConnectorImplSidebar
             logoSrc={`/connector-logos/${conn.connectorId}.png`}
             title={displayName}
+            identifier={conn.connectorId}
             description={description}
             tags={tags}
             sourceHref={registryUrl}

--- a/apps/connectors-docs/components/connector-details-sidebar.tsx
+++ b/apps/connectors-docs/components/connector-details-sidebar.tsx
@@ -35,6 +35,12 @@ export function ConnectorDetailsSidebar({
       {typeof thumbsUpCount === "number" && (
         <div className="text-sm text-muted-foreground">👍 {thumbsUpCount}</div>
       )}
+      <div className="space-y-2">
+        <div className="text-xs font-medium text-muted-foreground">
+          Identifier
+        </div>
+        <code className="text-sm font-mono">{connectorId}</code>
+      </div>
       {description ? (
         <p className="text-muted-foreground">{description}</p>
       ) : null}

--- a/apps/connectors-docs/components/connector-impl-sidebar.tsx
+++ b/apps/connectors-docs/components/connector-impl-sidebar.tsx
@@ -21,6 +21,7 @@ type SidebarSectionItem = {
 export type ConnectorImplSidebarProps = {
   logoSrc: string;
   title: string;
+  identifier: string;
   description?: string;
   tags?: string[];
   sourceHref?: string;
@@ -42,6 +43,7 @@ export default function ConnectorImplSidebar(props: ConnectorImplSidebarProps) {
   const {
     logoSrc,
     title,
+    identifier,
     description,
     tags = [],
     sourceHref,
@@ -161,6 +163,13 @@ export default function ConnectorImplSidebar(props: ConnectorImplSidebarProps) {
       {description ? (
         <p className="text-muted-foreground">{description}</p>
       ) : null}
+
+      <div className="space-y-2">
+        <div className="text-xs text-muted-foreground font-medium">
+          Identifier
+        </div>
+        <code className="text-sm font-mono">{identifier}</code>
+      </div>
 
       <div className="space-y-6">
         {renderSection(

--- a/apps/pipelines-docs/components/connector-details-sidebar.tsx
+++ b/apps/pipelines-docs/components/connector-details-sidebar.tsx
@@ -35,6 +35,12 @@ export function ConnectorDetailsSidebar({
       {typeof thumbsUpCount === "number" && (
         <div className="text-sm text-muted-foreground">👍 {thumbsUpCount}</div>
       )}
+      <div className="space-y-2">
+        <div className="text-xs font-medium text-muted-foreground">
+          Identifier
+        </div>
+        <code className="text-sm font-mono">{connectorId}</code>
+      </div>
       {description ? (
         <p className="text-muted-foreground">{description}</p>
       ) : null}


### PR DESCRIPTION
## Summary
- Display connector identifier in sidebar with label for both docs and pipelines
- Accept identifier prop in implementation sidebar and surface it in connector pages

## Testing
- `pnpm lint` *(fails: Invalid Options: 'resolvePluginsRelativeTo' etc)*
- `pnpm typecheck` *(fails: Could not find task `typecheck` in project)*

------
https://chatgpt.com/codex/tasks/task_e_68b1dd0ca8dc8322a9daeba620b2101c