### PR TITLE
Add built-in logging and metrics hooks

### DIFF
--- a/connector-registry/hubspot/v3/514-labs/typescript/data-api/docs/configuration.md
+++ b/connector-registry/hubspot/v3/514-labs/typescript/data-api/docs/configuration.md
@@ -51,7 +51,49 @@ type ConnectorConfig = {
     onRetry?: Function[];
     onError?: Function[];
   };
+
+  // Observability (built-in hooks)
+  enableLogging?: boolean | { level?: "debug" | "info" | "warn" | "error"; includeQueryParams?: boolean; includeHeaders?: boolean; includeBody?: boolean };
+  enableMetrics?: boolean;
 }
 ```
 
 Defaults come from `withDerivedDefaults` (see `src/config/defaults.ts`). OAuth2 fields are part of the public types, but the current transport applies only Bearer tokens.
+
+## Observability
+
+Built-in logging and metrics hooks can be enabled without writing any custom code:
+
+```ts
+import { createHubSpotConnector } from "@connector-factory/hubspot";
+
+const connector = createHubSpotConnector();
+connector.initialize({
+  auth: { type: "bearer", bearer: { token: process.env.HUBSPOT_TOKEN! } },
+  enableLogging: { level: "info" },   // or true for defaults
+  enableMetrics: true,                 // in-memory counters/timings
+});
+```
+
+- With logging enabled, each request logs a one-line JSON like: `{ "event": "http_response", "method": "GET", "url": "https://api.hubapi.com/crm/v3/objects/contacts", "status": 200, "durationMs": 120, "retryCount": 0 }`.
+- With metrics enabled, the connector records counters and timings in an in-memory sink. You can access a sink by composing manually (see below).
+
+### Manual composition
+If you prefer manual control, you can import and attach the hooks yourself:
+
+```ts
+import { createLoggingHooks, createMetricsHooks, InMemoryMetricsSink } from "@connector-factory/hubspot";
+
+const logging = createLoggingHooks({ level: "info" });
+const { hooks: metricsHooks, sink } = createMetricsHooks({ sink: new InMemoryMetricsSink() }, { service: "hubspot" });
+
+connector.initialize({
+  auth: { type: "bearer", bearer: { token } },
+  hooks: {
+    ...logging,
+    ...metricsHooks,
+  },
+});
+
+// later: sink.getSnapshot() for simple inspection in tests/dev
+```

--- a/connector-registry/hubspot/v3/514-labs/typescript/data-api/src/config/defaults.ts
+++ b/connector-registry/hubspot/v3/514-labs/typescript/data-api/src/config/defaults.ts
@@ -1,4 +1,7 @@
 import type { ConnectorConfig } from "../types/config";
+import type { Hook, HookType } from "../types/hooks";
+import { createLoggingHooks } from "../observability/logging-hooks";
+import { createMetricsHooks } from "../observability/metrics-hooks";
 
 export function withDerivedDefaults(user: ConnectorConfig): ConnectorConfig {
   const base: ConnectorConfig = {
@@ -28,7 +31,8 @@ export function withDerivedDefaults(user: ConnectorConfig): ConnectorConfig {
     },
     hooks: {},
   };
-  return {
+
+  const merged: ConnectorConfig = {
     ...base,
     ...user,
     retry: { ...base.retry, ...user.retry },
@@ -36,6 +40,30 @@ export function withDerivedDefaults(user: ConnectorConfig): ConnectorConfig {
     defaultHeaders: { ...base.defaultHeaders, ...user.defaultHeaders },
     defaultQueryParams: { ...base.defaultQueryParams, ...user.defaultQueryParams },
   };
+
+  // Append built-in hooks based on enable flags
+  const hooks: Partial<Record<HookType, Hook[]>> = { ...(merged.hooks ?? {}) };
+
+  if (merged.enableLogging) {
+    const loggingOptions = typeof merged.enableLogging === "object" ? merged.enableLogging : { enabled: true };
+    const logging = createLoggingHooks(loggingOptions);
+    for (const phase of ["beforeRequest", "afterResponse", "onError", "onRetry"] as HookType[]) {
+      const toAdd = (logging as any)[phase] as Hook[] | undefined;
+      if (toAdd?.length) hooks[phase] = [ ...(hooks[phase] ?? []), ...toAdd ];
+    }
+  }
+
+  if (merged.enableMetrics) {
+    const metricsOptions = typeof merged.enableMetrics === "object" ? merged.enableMetrics : { enabled: true };
+    const { hooks: metrics } = createMetricsHooks(metricsOptions as any);
+    for (const phase of ["beforeRequest", "afterResponse", "onError", "onRetry"] as HookType[]) {
+      const toAdd = (metrics as any)[phase] as Hook[] | undefined;
+      if (toAdd?.length) hooks[phase] = [ ...(hooks[phase] ?? []), ...toAdd ];
+    }
+  }
+
+  merged.hooks = hooks;
+  return merged;
 }
 
 

--- a/connector-registry/hubspot/v3/514-labs/typescript/data-api/src/index.ts
+++ b/connector-registry/hubspot/v3/514-labs/typescript/data-api/src/index.ts
@@ -133,4 +133,7 @@ export type { HttpResponseEnvelope } from "./types/envelopes";
 // Export all model types for external use
 export type * from "./models";
 
+// Observability utilities for manual composition
+export { createLoggingHooks, createMetricsHooks, InMemoryMetricsSink } from "./observability";
+
 

--- a/connector-registry/hubspot/v3/514-labs/typescript/data-api/src/observability/index.ts
+++ b/connector-registry/hubspot/v3/514-labs/typescript/data-api/src/observability/index.ts
@@ -1,0 +1,2 @@
+export { createLoggingHooks } from "./logging-hooks";
+export { createMetricsHooks, InMemoryMetricsSink, createInMemoryMetricsSink } from "./metrics-hooks";

--- a/connector-registry/hubspot/v3/514-labs/typescript/data-api/src/observability/logging-hooks.ts
+++ b/connector-registry/hubspot/v3/514-labs/typescript/data-api/src/observability/logging-hooks.ts
@@ -1,0 +1,182 @@
+import type { Hook } from "../types/hooks";
+import type { HttpResponseEnvelope } from "../types/envelopes";
+import type { LogLevel, LoggingOptions } from "../types/config";
+
+function levelToNum(level: LogLevel): number {
+  switch (level) {
+    case "debug":
+      return 10;
+    case "info":
+      return 20;
+    case "warn":
+      return 30;
+    case "error":
+      return 40;
+    default:
+      return 20;
+  }
+}
+
+function isEnabled(min: LogLevel, lvl: LogLevel): boolean {
+  return levelToNum(lvl) >= levelToNum(min);
+}
+
+function writeConsole(level: LogLevel, event: Record<string, unknown>) {
+  const line = JSON.stringify(event);
+  if (level === "debug") {
+    console.debug(line);
+  } else if (level === "info") {
+    console.info(line);
+  } else if (level === "warn") {
+    console.warn(line);
+  } else {
+    console.error(line);
+  }
+}
+
+function safeJson(input: unknown): unknown {
+  try {
+    return JSON.parse(JSON.stringify(input));
+  } catch {
+    return undefined;
+  }
+}
+
+function computeItemCount(data: unknown): number | undefined {
+  if (Array.isArray(data)) return data.length;
+  if (data && typeof data === "object") {
+    const obj = data as Record<string, unknown>;
+    const items = obj.items ?? obj.results;
+    if (Array.isArray(items)) return items.length;
+  }
+  return undefined;
+}
+
+export function createLoggingHooks(options: LoggingOptions = {}): Partial<Record<"beforeRequest" | "afterResponse" | "onError" | "onRetry", Hook[]>> {
+  const {
+    level = "info",
+    includeQueryParams = false,
+    includeHeaders = false,
+    includeBody = false,
+    logger = writeConsole,
+  } = options;
+
+  const beforeRequest: Hook = {
+    name: "log-before-request",
+    priority: 1000,
+    execute: (ctx) => {
+      if (ctx.type !== "beforeRequest" || !ctx.request) return;
+      if (!isEnabled(level, "info")) return;
+      try {
+        const req = ctx.request as { method?: unknown; url?: unknown; headers?: unknown; body?: unknown };
+        const urlStr = String(req.url ?? "");
+        const u = urlStr ? new URL(urlStr) : undefined;
+        const event: Record<string, unknown> = {
+          ts: new Date().toISOString(),
+          event: "http_request",
+          phase: "beforeRequest",
+          operation: ctx.operation,
+          method: req.method,
+          url: includeQueryParams ? urlStr : (u ? `${u.origin}${u.pathname}` : urlStr),
+          host: u?.hostname,
+          path: u?.pathname,
+        };
+        if (includeQueryParams && u) {
+          const query: Record<string, string> = {};
+          u.searchParams.forEach((v, k) => (query[k] = v));
+          event.query = query;
+        }
+        if (includeHeaders) event.headers = safeJson(req.headers);
+        if (includeBody) event.body = safeJson((req as any).body);
+        logger("info", event);
+      } catch (e) {
+        // Best-effort logging; never throw
+      }
+    },
+  };
+
+  const afterResponse: Hook = {
+    name: "log-after-response",
+    priority: 1000,
+    execute: (ctx) => {
+      if (ctx.type !== "afterResponse" || !ctx.response || !ctx.request) return;
+      if (!isEnabled(level, "info")) return;
+      try {
+        const res = ctx.response as HttpResponseEnvelope<unknown>;
+        const req = ctx.request as { method?: unknown; url?: unknown };
+        const urlStr = String((req as any).url ?? "");
+        const u = urlStr ? new URL(urlStr) : undefined;
+        const event: Record<string, unknown> = {
+          ts: new Date().toISOString(),
+          event: "http_response",
+          phase: "afterResponse",
+          operation: ctx.operation,
+          method: req.method,
+          url: includeQueryParams ? urlStr : (u ? `${u.origin}${u.pathname}` : urlStr),
+          status: res.status,
+          durationMs: res.meta?.durationMs,
+          retryCount: res.meta?.retryCount,
+          requestId: res.meta?.requestId,
+          itemCount: computeItemCount(res.data),
+        };
+        logger("info", event);
+      } catch {
+        // swallow
+      }
+    },
+  };
+
+  const onError: Hook = {
+    name: "log-on-error",
+    priority: 1000,
+    execute: (ctx) => {
+      if (ctx.type !== "onError" || !ctx.error) return;
+      if (!isEnabled(level, "error")) return;
+      try {
+        const err = ctx.error as any;
+        const event: Record<string, unknown> = {
+          ts: new Date().toISOString(),
+          event: "http_error",
+          phase: "onError",
+          operation: ctx.operation,
+          message: String(err?.message ?? err),
+          code: err?.code,
+          statusCode: err?.statusCode,
+          requestId: err?.requestId,
+          source: err?.source,
+        };
+        logger("error", event);
+      } catch {
+        // swallow
+      }
+    },
+  };
+
+  const onRetry: Hook = {
+    name: "log-on-retry",
+    priority: 1000,
+    execute: (ctx) => {
+      if (ctx.type !== "onRetry") return;
+      if (!isEnabled(level, "debug")) return;
+      try {
+        const event: Record<string, unknown> = {
+          ts: new Date().toISOString(),
+          event: "http_retry",
+          phase: "onRetry",
+          operation: (ctx.metadata as any)?.operation ?? ctx.operation,
+          attempt: (ctx.metadata as any)?.attempt,
+        };
+        logger("debug", event);
+      } catch {
+        // swallow
+      }
+    },
+  };
+
+  return {
+    beforeRequest: [beforeRequest],
+    afterResponse: [afterResponse],
+    onError: [onError],
+    onRetry: [onRetry],
+  };
+}

--- a/connector-registry/hubspot/v3/514-labs/typescript/data-api/src/observability/metrics-hooks.ts
+++ b/connector-registry/hubspot/v3/514-labs/typescript/data-api/src/observability/metrics-hooks.ts
@@ -1,0 +1,104 @@
+import type { Hook } from "../types/hooks";
+import type { MetricsLabels, MetricsOptions, MetricsSink } from "../types/config";
+
+function labelsKey(labels?: MetricsLabels): string {
+  if (!labels) return "";
+  const entries = Object.entries(labels).filter(([, v]) => v !== undefined);
+  entries.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  return entries.map(([k, v]) => `${k}=${String(v)}`).join(",");
+}
+
+export class InMemoryMetricsSink implements MetricsSink {
+  private counters = new Map<string, number>();
+  private observations = new Map<string, { count: number; sum: number }>();
+
+  incrementCounter(name: string, value: number = 1, labels?: MetricsLabels): void {
+    const key = `${name}|${labelsKey(labels)}`;
+    const prev = this.counters.get(key) ?? 0;
+    this.counters.set(key, prev + value);
+  }
+
+  observe(name: string, value: number, labels?: MetricsLabels): void {
+    const key = `${name}|${labelsKey(labels)}`;
+    const prev = this.observations.get(key) ?? { count: 0, sum: 0 };
+    prev.count += 1;
+    prev.sum += value;
+    this.observations.set(key, prev);
+  }
+
+  getSnapshot() {
+    const counters: Record<string, number> = {};
+    for (const [k, v] of this.counters.entries()) counters[k] = v;
+    const observations: Record<string, { count: number; sum: number; avg: number }> = {};
+    for (const [k, v] of this.observations.entries()) observations[k] = { count: v.count, sum: v.sum, avg: v.count ? v.sum / v.count : 0 };
+    return { counters, observations };
+  }
+}
+
+export function createInMemoryMetricsSink(): { sink: InMemoryMetricsSink } {
+  return { sink: new InMemoryMetricsSink() };
+}
+
+export function createMetricsHooks(options: MetricsOptions = {}, staticLabels: MetricsLabels = {}): { hooks: Partial<Record<"beforeRequest" | "afterResponse" | "onError" | "onRetry", Hook[]>>; sink: MetricsSink } {
+  const sink: MetricsSink = options.sink ?? new InMemoryMetricsSink();
+  const enabled = options.enabled !== false; // default true if provided via flag
+
+  const hooks: Partial<Record<"beforeRequest" | "afterResponse" | "onError" | "onRetry", Hook[]>> = {};
+  if (enabled) {
+    hooks.afterResponse = [
+      {
+        name: "metrics-after-response",
+        priority: 1000,
+        execute: (ctx) => {
+          if (ctx.type !== "afterResponse" || !ctx.response) return;
+          try {
+            const res: any = ctx.response;
+            const success = res.status >= 200 && res.status < 300;
+            const duration = Number(res.meta?.durationMs ?? 0);
+            const labels: MetricsLabels = { ...staticLabels, operation: ctx.operation, status: res.status, success };
+            sink.incrementCounter("http_requests_total", 1, labels);
+            if (Number.isFinite(duration)) sink.observe("http_request_duration_ms", duration, labels);
+          } catch {
+            // swallow
+          }
+        },
+      },
+    ];
+
+    hooks.onError = [
+      {
+        name: "metrics-on-error",
+        priority: 1000,
+        execute: (ctx) => {
+          if (ctx.type !== "onError" || !ctx.error) return;
+          try {
+            const err: any = ctx.error;
+            const labels: MetricsLabels = { ...staticLabels, operation: ctx.operation, code: err?.code, source: err?.source };
+            sink.incrementCounter("http_errors_total", 1, labels);
+          } catch {
+            // swallow
+          }
+        },
+      },
+    ];
+
+    hooks.onRetry = [
+      {
+        name: "metrics-on-retry",
+        priority: 1000,
+        execute: (ctx) => {
+          if (ctx.type !== "onRetry") return;
+          try {
+            const op = (ctx.metadata as any)?.operation ?? ctx.operation;
+            const labels: MetricsLabels = { ...staticLabels, operation: op };
+            sink.incrementCounter("http_retries_total", 1, labels);
+          } catch {
+            // swallow
+          }
+        },
+      },
+    ];
+  }
+
+  return { hooks, sink };
+}

--- a/connector-registry/hubspot/v3/514-labs/typescript/data-api/src/types/config.ts
+++ b/connector-registry/hubspot/v3/514-labs/typescript/data-api/src/types/config.ts
@@ -1,5 +1,30 @@
 import type { Hook, HookType } from "./hooks";
 
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+export interface LoggingOptions {
+  enabled?: boolean;
+  level?: LogLevel;
+  includeQueryParams?: boolean;
+  includeHeaders?: boolean;
+  includeBody?: boolean;
+  logger?: (level: LogLevel, event: Record<string, unknown>) => void;
+}
+
+export interface MetricsLabels {
+  [key: string]: string | number | boolean | undefined;
+}
+
+export interface MetricsSink {
+  incrementCounter: (name: string, value?: number, labels?: MetricsLabels) => void;
+  observe: (name: string, value: number, labels?: MetricsLabels) => void;
+}
+
+export interface MetricsOptions {
+  enabled?: boolean;
+  sink?: MetricsSink;
+}
+
 export interface ConnectorAuthConfig {
   type: "bearer" | "oauth2";
   bearer?: { token: string };
@@ -40,6 +65,9 @@ export interface ConnectorConfig {
   retry?: RetryConfig;
   rateLimit?: RateLimitConfig;
   hooks?: Partial<Record<HookType, Hook[]>>;
+  // Observability (built-in hooks)
+  enableLogging?: boolean | LoggingOptions;
+  enableMetrics?: boolean | MetricsOptions;
 }
 
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,10 +275,6 @@ importers:
         specifier: ^5
         version: 5.8.3
 
-  connector-registry/google-analytics/v4/514-labs/typescript/data-api: {}
-
-  connector-registry/google-analytics/v4/tg339/typescript/data-api: {}
-
   connector-registry/hubspot/v3/514-labs/typescript/data-api:
     dependencies:
       zod:


### PR DESCRIPTION
Introduce out-of-the-box logging and metrics hooks for enhanced connector observability.

---
<a href="https://cursor.com/background-agent?bcId=bc-b51a637b-d4aa-452c-96a2-8895cb462b63">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b51a637b-d4aa-452c-96a2-8895cb462b63">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

