### PR TITLE
Scaffold new connector and pipeline projects

### DIFF
--- a/packages/factory-cli/README.md
+++ b/packages/factory-cli/README.md
@@ -1,0 +1,64 @@
+# Factory CLI
+
+A Node.js CLI to scaffold new connectors and pipelines from the repository's JSON scaffold templates.
+
+## Install (in this monorepo)
+
+```bash
+pnpm -C packages/factory-cli install
+pnpm -C packages/factory-cli build
+```
+
+Optionally link the binary:
+
+```bash
+pnpm -C packages/factory-cli link --global
+```
+
+## Usage
+
+- Show help:
+
+```bash
+node packages/factory-cli/dist/index.js --help
+```
+
+- Scaffold connector/pipeline metadata only:
+
+```bash
+node packages/factory-cli/dist/index.js scaffold connector meta \
+  --name hubspot \
+  --scaffold-version v3 \
+  --author 514-labs \
+  --yes
+```
+
+- Scaffold TypeScript implementation (connector example):
+
+```bash
+node packages/factory-cli/dist/index.js scaffold connector typescript \
+  --name hubspot \
+  --scaffold-version v3 \
+  --author 514-labs \
+  --implementation default \
+  --package-name @workspace/connector-hubspot \
+  --resource contacts \
+  --yes
+```
+
+- Dry run without writing files:
+
+```bash
+node packages/factory-cli/dist/index.js scaffold pipeline typescript \
+  --name google-analytics-to-clickhouse \
+  --scaffold-version v1 \
+  --author 514-labs \
+  --dry-run \
+  --yes
+```
+
+## Notes
+
+- The CLI auto-detects the repo root from the current working directory.
+- Variables are validated against patterns defined in the scaffold JSON.
+- Placeholders like `{connector}`, `{pipeline}`, `{author}`, `{version}` are replaced in paths and templates.

--- a/packages/factory-cli/package.json
+++ b/packages/factory-cli/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@workspace/factory-cli",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "factory": "dist/index.js"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts",
+    "dev": "tsup src/index.ts --watch --format esm,cjs --dts"
+  },
+  "dependencies": {
+    "commander": "^12.1.0",
+    "kleur": "^4.1.5",
+    "prompts": "^2.4.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.7.4",
+    "tsup": "^8.3.5",
+    "typescript": "^5.6.3"
+  },
+  "engines": {"node": ">=20"}
+}
+

--- a/packages/factory-cli/src/index.ts
+++ b/packages/factory-cli/src/index.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+import { Command } from 'commander'
+import pkg from '../package.json' assert { type: 'json' }
+import { runScaffold } from './scaffold'
+
+const program = new Command()
+program
+  .name('factory')
+  .description('Connector & Pipeline Factory CLI')
+  .version(pkg.version)
+
+program
+  .command('scaffold')
+  .description('Generate a new connector or pipeline from scaffold templates')
+  .argument('<kind>', 'connector | pipeline')
+  .argument('<language>', 'typescript | python | meta')
+  .option('-n, --name <name>', 'connector/pipeline id (kebab-case)')
+  .option('--scaffold-version <version>', 'version identifier (e.g. v1, v3, ga4)')
+  .option('-a, --author <author>', 'author org/user (kebab-case)')
+  .option('-i, --implementation <impl>', "implementation name under language (default: 'default')")
+  .option('--package-name <pkg>', 'package name for lang impl (npm or python package)')
+  .option('--resource <resource>', 'default resource path segment (kebab-case)')
+  .option('--dry-run', 'print planned operations without writing files')
+  .option('-y, --yes', 'skip prompts and use provided flags/defaults')
+  .action(async (kind, language, opts) => {
+    await runScaffold({ kind, language, options: opts })
+  })
+
+program.parseAsync(process.argv)
+

--- a/packages/factory-cli/src/index.ts
+++ b/packages/factory-cli/src/index.ts
@@ -26,5 +26,10 @@ program
     await runScaffold({ kind, language, options: opts })
   })
 
-program.parseAsync(process.argv)
+try {
+  await program.parseAsync(process.argv)
+} catch (error) {
+  console.error(error)
+  process.exit(1)
+}
 

--- a/packages/factory-cli/src/index.ts
+++ b/packages/factory-cli/src/index.ts
@@ -9,6 +9,9 @@ program
   .description('Connector & Pipeline Factory CLI')
   .version(pkg.version)
 
+// Ensure parsing/validation errors cause non-zero exit codes when awaited
+program.exitOverride()
+
 program
   .command('scaffold')
   .description('Generate a new connector or pipeline from scaffold templates')
@@ -26,10 +29,13 @@ program
     await runScaffold({ kind, language, options: opts })
   })
 
-try {
+async function main() {
   await program.parseAsync(process.argv)
-} catch (error) {
-  console.error(error)
-  process.exit(1)
 }
+
+main().catch((error: any) => {
+  console.error(error)
+  const code = typeof error?.exitCode === 'number' ? error.exitCode : 1
+  process.exit(code)
+})
 

--- a/packages/factory-cli/src/scaffold.ts
+++ b/packages/factory-cli/src/scaffold.ts
@@ -158,8 +158,8 @@ export async function runScaffold({ kind, language, options }: { kind: Kind; lan
   }
 
   const vars: Record<string, string> = {
-    connector: id,
-    pipeline: id,
+    connector: kind === 'connector' ? id : '',
+    pipeline: kind === 'pipeline' ? id : '',
     version: answers.version,
     author: answers.author,
     implementation: answers.implementation ?? '',
@@ -169,7 +169,7 @@ export async function runScaffold({ kind, language, options }: { kind: Kind; lan
 
   const targetRoot = path.join(repoRoot, kind === 'connector' ? 'connector-registry' : 'pipeline-registry')
   const ops: string[] = []
-  await applyStructure(targetRoot, scaffold.structure, vars, Boolean(options.dryRun), ops, kind === 'connector' ? '{connector}' : '{pipeline}')
+  await applyStructure(targetRoot, scaffold.structure, vars, Boolean(options.dryRun), ops)
 
   const headline = options.dryRun ? kleur.yellow('Dry run: no files written') : kleur.green('Scaffold created')
   console.log(headline)

--- a/packages/factory-cli/src/scaffold.ts
+++ b/packages/factory-cli/src/scaffold.ts
@@ -1,0 +1,191 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import prompts from 'prompts'
+import kleur from 'kleur'
+
+export type Kind = 'connector' | 'pipeline'
+export type Language = 'typescript' | 'python' | 'meta'
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function findRepoRoot(startDir: string): Promise<string> {
+  let dir = path.resolve(startDir)
+  while (true) {
+    const ws = path.join(dir, 'pnpm-workspace.yaml')
+    const hasWorkspace = await pathExists(ws)
+    const hasRegistries = await pathExists(path.join(dir, 'connector-registry'))
+    if (hasWorkspace || hasRegistries) return dir
+    const parent = path.dirname(dir)
+    if (parent === dir) return startDir
+    dir = parent
+  }
+}
+
+function assertPattern(value: string | undefined, pattern: string, label: string): string {
+  if (!value) throw new Error(`${label} is required`)
+  const re = new RegExp(pattern)
+  if (!re.test(value)) throw new Error(`${label} does not match pattern ${pattern}: ${value}`)
+  return value
+}
+
+function replaceTemplatePlaceholders(input: string, values: Record<string, string>): string {
+  return input.replace(/\{(\w+)\}/g, (_, k) => values[k] ?? '')
+}
+
+type StructureNode =
+  | { type: 'dir'; name: string; children?: StructureNode[] }
+  | { type: 'file'; name: string; template?: string }
+
+type ScaffoldFile = {
+  $schema?: string
+  scaffold: string
+  version: string
+  description?: string
+  variables: Record<string, { description?: string; example?: string; pattern?: string; default?: string }>
+  structure: StructureNode[]
+}
+
+async function readJson(file: string): Promise<any> {
+  const buf = await fs.readFile(file, 'utf8')
+  return JSON.parse(buf)
+}
+
+function getScaffoldPath(repoRoot: string, kind: Kind, language: Language): string {
+  const base = language === 'meta' ? 'meta' : language
+  const registryDir = kind === 'connector' ? 'connector-registry' : 'pipeline-registry'
+  const filename = base === 'meta' ? 'meta.json' : `${base}.json`
+  return path.join(repoRoot, registryDir, '_scaffold', filename)
+}
+
+async function ensureDir(p: string) {
+  await fs.mkdir(p, { recursive: true })
+}
+
+async function writeFile(p: string, content: string) {
+  await ensureDir(path.dirname(p))
+  await fs.writeFile(p, content, 'utf8')
+}
+
+async function applyStructure(targetRoot: string, nodes: StructureNode[], vars: Record<string, string>, dryRun: boolean, log: string[] = [], rel = '.') {
+  for (const node of nodes) {
+    const name = replaceTemplatePlaceholders(node.name, vars)
+    const currentPath = path.join(targetRoot, name)
+    const relPath = path.posix.join(rel, name.replaceAll('\\', '/'))
+    if (node.type === 'dir') {
+      log.push(kleur.cyan(`mkdir ${relPath}/`))
+      if (!dryRun) await ensureDir(currentPath)
+      if (node.children?.length) await applyStructure(targetRoot, node.children, vars, dryRun, log, relPath)
+    } else if (node.type === 'file') {
+      const content = replaceTemplatePlaceholders(node.template ?? '', vars)
+      log.push(kleur.green(`write ${relPath}`))
+      if (!dryRun) await writeFile(currentPath, content)
+    }
+  }
+}
+
+function suggestPackageName(kind: Kind, language: Language, id: string): string {
+  if (language === 'python') return `${kind}_${id.replaceAll('-', '_')}`
+  return `@workspace/${kind}-${id}`
+}
+
+export async function runScaffold({ kind, language, options }: { kind: Kind; language: Language; options: any }) {
+  const repoRoot = await findRepoRoot(process.cwd())
+  const scaffoldPath = getScaffoldPath(repoRoot, kind, language)
+  const scaffold: ScaffoldFile = await readJson(scaffoldPath)
+
+  const varsSpec = scaffold.variables
+  const ask = async () => {
+    const questions: prompts.PromptObject[] = []
+    const pushQ = (name: string, message: string, initial?: string) => {
+      questions.push({ type: 'text', name, message, initial })
+    }
+
+    if (kind === 'connector') {
+      pushQ('connector', 'Connector id (kebab-case)', options.name)
+    } else {
+      pushQ('pipeline', 'Pipeline id (kebab-case)', options.name)
+    }
+    pushQ('version', 'Version (e.g. v1, ga4, 2024-10-01)', options.scaffoldVersion ?? options.version)
+    pushQ('author', 'Author org/user (kebab-case)', options.author)
+
+    if (language !== 'meta') {
+      pushQ('implementation', `Implementation (default: ${varsSpec.implementation?.default ?? 'default'})`, options.implementation ?? varsSpec.implementation?.default ?? 'default')
+      pushQ('packageName', 'Package name (npm or python)', options.packageName)
+      pushQ('resource', `Default resource (kebab-case)`, options.resource ?? 'resource')
+    }
+
+    const answers = options.yes ? {
+      connector: options.name,
+      pipeline: options.name,
+      version: options.scaffoldVersion ?? options.version,
+      author: options.author,
+      implementation: options.implementation ?? varsSpec.implementation?.default ?? 'default',
+      packageName: options.packageName,
+      resource: options.resource ?? 'resource',
+    } : await prompts(questions, { onCancel: () => { throw new Error('Cancelled') } })
+
+    return answers
+  }
+
+  const answers = await ask()
+
+  const idKey = kind === 'connector' ? 'connector' : 'pipeline'
+  const id = answers[idKey]
+
+  // validations
+  const idPattern = varsSpec[idKey]?.pattern ?? '^[a-z0-9][a-z0-9-]*$'
+  assertPattern(id, idPattern, `${kind} id`)
+  assertPattern(answers.version, varsSpec.version?.pattern ?? '^[A-Za-z0-9][A-Za-z0-9._-]*$', 'version')
+  assertPattern(answers.author, varsSpec.author?.pattern ?? '^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$', 'author')
+  if (language !== 'meta') {
+    assertPattern(answers.implementation, varsSpec.implementation?.pattern ?? '^[a-z0-9][a-z0-9-]*$', 'implementation')
+    if (!answers.packageName) answers.packageName = suggestPackageName(kind, language, id)
+    if (language === 'typescript') {
+      const npmPattern = varsSpec.packageName?.pattern ?? '^[a-z0-9-~][a-z0-9-._~]*$'
+      assertPattern(answers.packageName, npmPattern, 'packageName')
+    } else if (language === 'python') {
+      const pyPattern = varsSpec.packageName?.pattern ?? '^[a-z_][a-z0-9_]*$'
+      assertPattern(answers.packageName, pyPattern, 'packageName')
+    }
+    assertPattern(answers.resource, varsSpec.resource?.pattern ?? '^[a-z0-9][a-z0-9-]*$', 'resource')
+  }
+
+  const vars: Record<string, string> = {
+    connector: id,
+    pipeline: id,
+    version: answers.version,
+    author: answers.author,
+    implementation: answers.implementation ?? '',
+    packageName: answers.packageName ?? '',
+    resource: answers.resource ?? '',
+  }
+
+  const targetRoot = path.join(repoRoot, kind === 'connector' ? 'connector-registry' : 'pipeline-registry')
+  const ops: string[] = []
+  await applyStructure(targetRoot, scaffold.structure, vars, Boolean(options.dryRun), ops, kind === 'connector' ? '{connector}' : '{pipeline}')
+
+  const headline = options.dryRun ? kleur.yellow('Dry run: no files written') : kleur.green('Scaffold created')
+  console.log(headline)
+  for (const op of ops) console.log('  ' + op)
+
+  // Next steps
+  console.log('\nNext steps:')
+  if (language === 'meta') {
+    console.log(`- Add a language implementation later with: factory scaffold ${kind} typescript --name ${id} --version ${answers.version} --author ${answers.author}`)
+  } else if (language === 'typescript') {
+    console.log(`- Install deps in the new package (if needed): pnpm -F ${answers.packageName} install`)
+    console.log(`- Build TypeScript: pnpm -F ${answers.packageName} build`)
+    console.log(`- Start implementing in src/ under ${kind}/${id}/${answers.version}/${answers.author}/typescript/${answers.implementation}`)
+  } else if (language === 'python') {
+    console.log(`- Create a venv and install: cd to the impl dir and pip install -e .`)
+    console.log(`- Start implementing in src/ under ${kind}/${id}/${answers.version}/${answers.author}/python/${answers.implementation}`)
+  }
+}
+

--- a/packages/factory-cli/src/scaffold.ts
+++ b/packages/factory-cli/src/scaffold.ts
@@ -52,6 +52,8 @@ type ScaffoldFile = {
   structure: StructureNode[]
 }
 
+type PromptObject = { [key: string]: any }
+
 async function readJson(file: string): Promise<any> {
   const buf = await fs.readFile(file, 'utf8')
   return JSON.parse(buf)
@@ -81,7 +83,7 @@ async function applyStructure(targetRoot: string, nodes: StructureNode[], vars: 
     if (node.type === 'dir') {
       log.push(kleur.cyan(`mkdir ${relPath}/`))
       if (!dryRun) await ensureDir(currentPath)
-      if (node.children?.length) await applyStructure(targetRoot, node.children, vars, dryRun, log, relPath)
+      if (node.children?.length) await applyStructure(currentPath, node.children, vars, dryRun, log, relPath)
     } else if (node.type === 'file') {
       const content = replaceTemplatePlaceholders(node.template ?? '', vars)
       log.push(kleur.green(`write ${relPath}`))
@@ -102,7 +104,7 @@ export async function runScaffold({ kind, language, options }: { kind: Kind; lan
 
   const varsSpec = scaffold.variables
   const ask = async () => {
-    const questions: prompts.PromptObject[] = []
+    const questions: PromptObject[] = []
     const pushQ = (name: string, message: string, initial?: string) => {
       questions.push({ type: 'text', name, message, initial })
     }

--- a/packages/factory-cli/src/shims.d.ts
+++ b/packages/factory-cli/src/shims.d.ts
@@ -1,0 +1,3 @@
+declare module 'prompts'
+
+

--- a/packages/factory-cli/src/types/prompts.d.ts
+++ b/packages/factory-cli/src/types/prompts.d.ts
@@ -1,0 +1,12 @@
+declare module 'prompts' {
+  export interface PromptObject {
+    [key: string]: any
+  }
+
+  export type Prompt = PromptObject | PromptObject[]
+
+  function prompts(questions: Prompt, options?: any): Promise<any>
+  export default prompts
+}
+
+

--- a/packages/factory-cli/tsconfig.json
+++ b/packages/factory-cli/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,10 +275,6 @@ importers:
         specifier: ^5
         version: 5.8.3
 
-  connector-registry/google-analytics/v4/514-labs/typescript/data-api: {}
-
-  connector-registry/google-analytics/v4/tg339/typescript/data-api: {}
-
   connector-registry/hubspot/v3/514-labs/typescript/data-api:
     dependencies:
       zod:
@@ -325,11 +321,33 @@ importers:
         specifier: ^15.0.0
         version: 15.15.0
 
+  packages/factory-cli:
+    dependencies:
+      commander:
+        specifier: ^12.1.0
+        version: 12.1.0
+      kleur:
+        specifier: ^4.1.5
+        version: 4.1.5
+      prompts:
+        specifier: ^2.4.2
+        version: 2.4.2
+    devDependencies:
+      '@types/node':
+        specifier: ^22.7.4
+        version: 22.18.0
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.0(@swc/core@1.13.3(@swc/helpers@0.5.17))(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.4)(typescript@5.8.3)
+      typescript:
+        specifier: ^5.6.3
+        version: 5.8.3
+
   packages/models:
     dependencies:
       '@514labs/moose-lib':
         specifier: latest
-        version: 0.5.23(@swc/core@1.13.3(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)(@types/node@24.2.0)(ts-patch@3.3.0)(typia@9.7.1(typescript@5.8.3))
+        version: 0.6.21(@swc/core@1.13.3(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)(@types/node@24.2.0)(ts-patch@3.3.0)(typia@9.7.1(typescript@5.8.3))
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -595,7 +613,7 @@ importers:
     dependencies:
       '@514labs/moose-lib':
         specifier: latest
-        version: 0.5.29(@swc/core@1.13.3(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)(@types/node@24.2.0)(ts-patch@3.3.0)(typia@9.7.1(typescript@5.8.3))
+        version: 0.6.21(@swc/core@1.13.3(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)(@types/node@24.2.0)(ts-patch@3.3.0)(typia@9.7.1(typescript@5.8.3))
       dotenv:
         specifier: ^16.4.5
         version: 16.6.1
@@ -605,7 +623,7 @@ importers:
     devDependencies:
       '@514labs/moose-cli':
         specifier: latest
-        version: 0.5.29
+        version: 0.6.21
       tsup:
         specifier: ^8.0.0
         version: 8.5.0(@swc/core@1.13.3(@swc/helpers@0.5.17))(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.4)(typescript@5.8.3)
@@ -646,43 +664,36 @@ importers:
 
 packages:
 
-  '@514labs/moose-cli-darwin-arm64@0.5.29':
-    resolution: {integrity: sha512-BX1AMotyskdYLIJD5AyTXX1hiOU3lW2fBtUspsnrOKzfkj1kHepXTNPdwv9qC58BepH7Qm3/akZo3D25qrKsQA==}
+  '@514labs/moose-cli-darwin-arm64@0.6.21':
+    resolution: {integrity: sha512-DA8+21fOtLIdJ9xwC+/j4iU3XYRnzsYrFbXm7rf0mPxa3jFtbv0o0iPiBoFrRYGKbirURmxQEnNl6+bonkZjnQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@514labs/moose-cli-darwin-x64@0.5.29':
-    resolution: {integrity: sha512-B3VWE+gMLlpkLrsB4hwdfSMb60dQMY0UBo4urL5orhanYqxWSAWSNdg4cIXMkWbWV+D29/1LSNjHu1xjulcEqw==}
+  '@514labs/moose-cli-darwin-x64@0.6.21':
+    resolution: {integrity: sha512-3N0LQlzh/AlWEFyW976pK+XMBv8YBJ4xKExLAlO6UaJVKQTgvbkutEtozPZKjndo8r2w0PKYe/8T3kAx4M8DLg==}
     cpu: [x64]
     os: [darwin]
 
-  '@514labs/moose-cli-linux-arm64@0.5.29':
-    resolution: {integrity: sha512-lPCMWse9PpGns7vGPjy7wny7a+xjGkhYWbidI0+l2iFOHTez8l3TKXllR7OgdFdlSy84eW3aIF8aXAhQLQOPYQ==}
+  '@514labs/moose-cli-linux-arm64@0.6.21':
+    resolution: {integrity: sha512-zYaR/AavptMVd0U6lCLo50p3Spsj+Jv01eBSiNJKqB8wJ2Ri/3MvKPQzYiSS8ApXBQMvorEgTrDzL7HwJTBr3A==}
     cpu: [arm64]
     os: [linux]
 
-  '@514labs/moose-cli-linux-x64@0.5.29':
-    resolution: {integrity: sha512-uyZxywGdO6+qr0j+Z2b8mR8Ayo0ArBb4ujcyNt7YCIp33QAsU0UEEYep3KEtQXfddC28baHeCfC+dmATdNtyKg==}
+  '@514labs/moose-cli-linux-x64@0.6.21':
+    resolution: {integrity: sha512-rkCRWoKkG5iD6dKdjiDNh5NaI6Hc+RL/G5ZgRbEvwLYXimXZPOfPU3Bt0E5oQEIPCigy/Olm9qPPf7eWpqhrwA==}
     cpu: [x64]
     os: [linux]
 
-  '@514labs/moose-cli@0.5.29':
-    resolution: {integrity: sha512-/9KZ5J6Q4SnYUBnN0ZUpDiYIRjJPHVGIHArVwF1BX14xcjuozf15OBL9XI8XQYdnxRHi4zqRHWl3MZQOFwjyUA==}
+  '@514labs/moose-cli@0.6.21':
+    resolution: {integrity: sha512-upPTVIGxFaeE2c1C109Ri82og4LZfsE9WYwrEkh9OEUB+zR9eiOEayv4xjvGHT1SjD0hihtYt1HlfzrAykA9eg==}
     hasBin: true
 
-  '@514labs/moose-lib@0.5.23':
-    resolution: {integrity: sha512-B6peQMfJ7BefgGAUFIsZ3s2Jsa9H1AUNJv+4moH39p3iCUNpnU84aTMsw/qC+ARadFTNE6V2zjk82EmG+EABEA==}
+  '@514labs/moose-lib@0.6.21':
+    resolution: {integrity: sha512-mC10a4dxxSkV5K/If1h3SrDXt1pPmFWB2kjuxji0qQ5+4d+df8shoWqy6NsHBJPgjEEwfqR2Ip/rkLU4JiFUwQ==}
     hasBin: true
     peerDependencies:
       ts-patch: ^3.3.0
-      typia: ^7.6.0
-
-  '@514labs/moose-lib@0.5.29':
-    resolution: {integrity: sha512-TeWmWoVT+5SzqsqU8YQgQMAhS7laRm+qjyWpcTisF4vU3D32nK3EPL9P4ydnbh0iSGDmbm1L1Mm6PPL6GG118Q==}
-    hasBin: true
-    peerDependencies:
-      ts-patch: ^3.3.0
-      typia: ^7.6.0
+      typia: ^9.6.1
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -3142,6 +3153,9 @@ packages:
   '@types/node@20.19.9':
     resolution: {integrity: sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==}
 
+  '@types/node@22.18.0':
+    resolution: {integrity: sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==}
+
   '@types/node@24.2.0':
     resolution: {integrity: sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==}
 
@@ -3885,6 +3899,10 @@ packages:
   commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
+
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
 
   commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
@@ -5301,6 +5319,10 @@ packages:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
 
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
 
@@ -6591,6 +6613,7 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
@@ -7054,11 +7077,6 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
-  typescript@5.7.3:
-    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
@@ -7444,26 +7462,26 @@ packages:
 
 snapshots:
 
-  '@514labs/moose-cli-darwin-arm64@0.5.29':
+  '@514labs/moose-cli-darwin-arm64@0.6.21':
     optional: true
 
-  '@514labs/moose-cli-darwin-x64@0.5.29':
+  '@514labs/moose-cli-darwin-x64@0.6.21':
     optional: true
 
-  '@514labs/moose-cli-linux-arm64@0.5.29':
+  '@514labs/moose-cli-linux-arm64@0.6.21':
     optional: true
 
-  '@514labs/moose-cli-linux-x64@0.5.29':
+  '@514labs/moose-cli-linux-x64@0.6.21':
     optional: true
 
-  '@514labs/moose-cli@0.5.29':
+  '@514labs/moose-cli@0.6.21':
     optionalDependencies:
-      '@514labs/moose-cli-darwin-arm64': 0.5.29
-      '@514labs/moose-cli-darwin-x64': 0.5.29
-      '@514labs/moose-cli-linux-arm64': 0.5.29
-      '@514labs/moose-cli-linux-x64': 0.5.29
+      '@514labs/moose-cli-darwin-arm64': 0.6.21
+      '@514labs/moose-cli-darwin-x64': 0.6.21
+      '@514labs/moose-cli-linux-arm64': 0.6.21
+      '@514labs/moose-cli-linux-x64': 0.6.21
 
-  '@514labs/moose-lib@0.5.23(@swc/core@1.13.3(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)(@types/node@24.2.0)(ts-patch@3.3.0)(typia@9.7.1(typescript@5.8.3))':
+  '@514labs/moose-lib@0.6.21(@swc/core@1.13.3(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)(@types/node@24.2.0)(ts-patch@3.3.0)(typia@9.7.1(typescript@5.8.3))':
     dependencies:
       '@clickhouse/client': 1.8.1
       '@clickhouse/client-web': 1.5.0
@@ -7479,38 +7497,9 @@ snapshots:
       kafkajs: 2.2.4
       redis: 4.7.1
       toml: 3.0.0
-      ts-node: 10.9.2(@swc/core@1.13.3(@swc/helpers@0.5.17))(@types/node@24.2.0)(typescript@5.7.3)
+      ts-node: 10.9.2(@swc/core@1.13.3(@swc/helpers@0.5.17))(@types/node@24.2.0)(typescript@5.9.2)
       ts-patch: 3.3.0
-      typescript: 5.7.3
-      typia: 9.7.1(typescript@5.8.3)
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/helpers'
-      - '@swc/wasm'
-      - '@types/node'
-      - esbuild
-      - uglify-js
-      - webpack-cli
-
-  '@514labs/moose-lib@0.5.29(@swc/core@1.13.3(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)(@types/node@24.2.0)(ts-patch@3.3.0)(typia@9.7.1(typescript@5.8.3))':
-    dependencies:
-      '@clickhouse/client': 1.8.1
-      '@clickhouse/client-web': 1.5.0
-      '@temporalio/activity': 1.12.1
-      '@temporalio/client': 1.12.1
-      '@temporalio/common': 1.12.1
-      '@temporalio/worker': 1.12.1(@swc/helpers@0.5.17)
-      '@temporalio/workflow': 1.12.1
-      commander: 13.1.0
-      csv-parse: 5.6.0
-      fastq: 1.17.1
-      jose: 5.9.2
-      kafkajs: 2.2.4
-      redis: 4.7.1
-      toml: 3.0.0
-      ts-node: 10.9.2(@swc/core@1.13.3(@swc/helpers@0.5.17))(@types/node@24.2.0)(typescript@5.7.3)
-      ts-patch: 3.3.0
-      typescript: 5.7.3
+      typescript: 5.9.2
       typia: 9.7.1(typescript@5.8.3)
     transitivePeerDependencies:
       - '@swc/core'
@@ -10000,6 +9989,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@22.18.0':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@24.2.0':
     dependencies:
       undici-types: 7.10.0
@@ -10919,6 +10912,8 @@ snapshots:
   comma-separated-tokens@2.0.3: {}
 
   commander@10.0.1: {}
+
+  commander@12.1.0: {}
 
   commander@13.1.0: {}
 
@@ -12804,6 +12799,8 @@ snapshots:
   kind-of@6.0.3: {}
 
   kleur@3.0.3: {}
+
+  kleur@4.1.5: {}
 
   language-subtag-registry@0.3.23: {}
 
@@ -14852,26 +14849,6 @@ snapshots:
       '@swc/core': 1.13.3(@swc/helpers@0.5.17)
     optional: true
 
-  ts-node@10.9.2(@swc/core@1.13.3(@swc/helpers@0.5.17))(@types/node@24.2.0)(typescript@5.7.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 24.2.0
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.7.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.13.3(@swc/helpers@0.5.17)
-
   ts-node@10.9.2(@swc/core@1.13.3(@swc/helpers@0.5.17))(@types/node@24.2.0)(typescript@5.8.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -14887,6 +14864,26 @@ snapshots:
       diff: 4.0.2
       make-error: 1.3.6
       typescript: 5.8.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.13.3(@swc/helpers@0.5.17)
+
+  ts-node@10.9.2(@swc/core@1.13.3(@swc/helpers@0.5.17))(@types/node@24.2.0)(typescript@5.9.2):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 24.2.0
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.9.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
@@ -15027,8 +15024,6 @@ snapshots:
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
-
-  typescript@5.7.3: {}
 
   typescript@5.8.3: {}
 


### PR DESCRIPTION
Add a new `factory-cli` package to automate connector and pipeline project scaffolding.

This CLI reads existing JSON scaffold templates, prompts for necessary variables, validates inputs, replaces placeholders, and generates the standardized file/folder structure, eliminating manual setup and improving developer ergonomics and consistency. It includes a dry-run mode and prints actionable next steps after generation.

---
<a href="https://cursor.com/background-agent?bcId=bc-d554d478-0c35-4f4b-838e-a5fc401b5579">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d554d478-0c35-4f4b-838e-a5fc401b5579">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

