### PR TITLE
Adapt rate limiting using API feedback

### DIFF
--- a/connector-registry/hubspot/v3/514-labs/typescript/data-api/docs/configuration.md
+++ b/connector-registry/hubspot/v3/514-labs/typescript/data-api/docs/configuration.md
@@ -41,7 +41,7 @@ type ConnectorConfig = {
     requestsPerSecond?: number;             // default: 15
     concurrentRequests?: number;            // default: 10
     burstCapacity?: number;                 // default: 30
-    adaptiveFromHeaders?: boolean;          // default: true (reserved; not adaptive yet)
+    adaptiveFromHeaders?: boolean;          // default: true (when true, auto‑adapts using rate‑limit headers)
   };
 
   // Hooks

--- a/connector-registry/hubspot/v3/514-labs/typescript/data-api/docs/limits.md
+++ b/connector-registry/hubspot/v3/514-labs/typescript/data-api/docs/limits.md
@@ -5,6 +5,10 @@ HubSpot enforces rate limits (vary by plan, object, and endpoint). This connecto
 - Token‑bucket rate limiting wraps all requests:
   - Configure with `rateLimit.requestsPerSecond`, `burstCapacity`, and `concurrentRequests`.
   - When configured (`requestsPerSecond > 0`), a `TokenBucketLimiter` waits for a slot before each request.
+  - When `rateLimit.adaptiveFromHeaders=true` (default), the limiter adapts to API feedback:
+    - Honors `Retry-After` by pausing issuance for the hinted duration
+    - If `remaining=0` and `reset` is present, pauses until reset time
+    - Gradually throttles when remaining/limit is low; returns to baseline otherwise
 
 - Retries with exponential backoff + jitter:
   - Defaults: `maxAttempts=3`, `initialDelayMs=1000`, `maxDelayMs=30000`, `backoffMultiplier=2`, `retryBudgetMs=60000`.

--- a/connector-registry/hubspot/v3/514-labs/typescript/data-api/src/client/http-client.ts
+++ b/connector-registry/hubspot/v3/514-labs/typescript/data-api/src/client/http-client.ts
@@ -18,6 +18,7 @@ export interface HttpRequestOptions {
 
 export interface HttpClientOptions {
   applyAuth?: (req: { headers: Record<string, string> }) => void;
+  onRateLimitSignal?: (info: { limit?: number; remaining?: number; reset?: number; retryAfterSeconds?: number }) => void;
 }
 
 export class HttpClient {
@@ -127,6 +128,11 @@ export class HttpClient {
           reset: Number(hdrs["x-hubspot-ratelimit-reset"]),
           retryAfterSeconds: Number.isFinite(retryAfter) ? retryAfter : undefined,
         };
+
+        // Emit rate limit hints to adaptive limiter if provided
+        try {
+          this.options.onRateLimitSignal?.(rateLimit);
+        } catch {}
 
         const envelope: HttpResponseEnvelope<T> = {
           data: data as T,

--- a/connector-registry/hubspot/v3/514-labs/typescript/data-api/src/index.ts
+++ b/connector-registry/hubspot/v3/514-labs/typescript/data-api/src/index.ts
@@ -42,6 +42,12 @@ export class HubSpotApiConnector implements HubSpotConnector {
           headers["Authorization"] = `Bearer ${token}`;
         }
       },
+      onRateLimitSignal: (info) => {
+        // Only adapt when flag enabled
+        if (this.config?.rateLimit?.adaptiveFromHeaders && this.limiter) {
+          this.limiter.updateFromResponse(info);
+        }
+      },
     });
     const rps = this.config.rateLimit?.requestsPerSecond ?? 0;
     const capacity = this.config.rateLimit?.burstCapacity ?? rps;

--- a/connector-registry/hubspot/v3/514-labs/typescript/data-api/src/rate-limit/token-bucket.ts
+++ b/connector-registry/hubspot/v3/514-labs/typescript/data-api/src/rate-limit/token-bucket.ts
@@ -3,11 +3,14 @@ export class TokenBucketLimiter {
   private tokens: number;
   private refillPerSec: number;
   private lastRefill: number;
+  private baseRefillPerSec: number;
+  private cooldownUntilMs: number | undefined;
 
   constructor(params: { capacity: number; refillPerSec: number }) {
     this.capacity = Math.max(1, params.capacity);
     this.tokens = this.capacity;
     this.refillPerSec = Math.max(1, params.refillPerSec);
+    this.baseRefillPerSec = this.refillPerSec;
     this.lastRefill = Date.now();
   }
 
@@ -20,19 +23,94 @@ export class TokenBucketLimiter {
     this.lastRefill = now;
   }
 
+  private async sleep(ms: number) {
+    return new Promise((r) => setTimeout(r, ms));
+  }
+
+  private setCooldownFor(ms: number) {
+    const until = Date.now() + Math.max(0, ms);
+    if (!this.cooldownUntilMs || until > this.cooldownUntilMs) {
+      this.cooldownUntilMs = until;
+    }
+  }
+
+  /**
+   * Update limiter based on response headers/meta.
+   * Accepts HubSpot-style hints: limit, remaining, reset (sec or epoch-sec), retryAfterSeconds.
+   */
+  updateFromResponse(info?: { limit?: number; remaining?: number; reset?: number; retryAfterSeconds?: number }): void {
+    if (!info) return;
+
+    // Honor Retry-After explicitly
+    if (Number.isFinite(info.retryAfterSeconds) && (info.retryAfterSeconds as number) > 0) {
+      const seconds = info.retryAfterSeconds as number;
+      this.setCooldownFor(seconds * 1000);
+      // eslint-disable-next-line no-console
+      console.info(`[rate-limit] Retry-After=${seconds}s → pausing new requests`);
+    }
+
+    const hasRemaining = info.remaining !== undefined && Number.isFinite(info.remaining as number);
+    const hasLimit = info.limit !== undefined && Number.isFinite(info.limit as number);
+
+    if (hasRemaining) {
+      const remaining = Math.max(0, info.remaining as number);
+
+      // If we have exhausted the window and a reset is known, pause until reset
+      if (remaining <= 0 && info.reset !== undefined && Number.isFinite(info.reset as number)) {
+        const resetVal = info.reset as number;
+        const nowSec = Math.floor(Date.now() / 1000);
+        // Heuristic: treat values larger than nowSec as epoch seconds, otherwise seconds-from-now
+        const msUntil = resetVal > nowSec ? Math.max(0, (resetVal - nowSec) * 1000) : Math.max(0, resetVal * 1000);
+        if (msUntil > 0) {
+          this.setCooldownFor(msUntil);
+          // eslint-disable-next-line no-console
+          console.info(`[rate-limit] Remaining=0, reset in ~${Math.ceil(msUntil / 1000)}s → pausing new requests`);
+        }
+      }
+
+      // Adjust refill rate conservatively based on remaining/limit ratio when limit is known
+      if (hasLimit) {
+        const limit = Math.max(1, info.limit as number);
+        const fraction = Math.min(1, Math.max(0, remaining / limit));
+        let factor = 1;
+        if (fraction <= 0.10) factor = 0.5; // heavy throttle
+        else if (fraction <= 0.25) factor = 0.75; // moderate throttle
+        else if (fraction <= 0.5) factor = 0.9; // light throttle
+        else factor = 1.0; // back to baseline
+        const target = Math.max(1, Math.floor(this.baseRefillPerSec * factor));
+        if (target !== this.refillPerSec) {
+          this.refillPerSec = target;
+          // eslint-disable-next-line no-console
+          console.info(`[rate-limit] Adjusting pace → ${target}/s (remaining=${remaining}/${limit})`);
+        }
+      }
+    }
+  }
+
+  getStatus(): { capacity: number; tokens: number; refillPerSec: number; cooldownUntilMs?: number } {
+    return { capacity: this.capacity, tokens: this.tokens, refillPerSec: this.refillPerSec, cooldownUntilMs: this.cooldownUntilMs };
+  }
+
   canProceed(): boolean {
+    if (this.cooldownUntilMs && Date.now() < this.cooldownUntilMs) return false;
     this.refillTokens();
     return this.tokens >= 1;
   }
 
   async waitForSlot(): Promise<void> {
     while (true) {
+      const now = Date.now();
+      if (this.cooldownUntilMs && now < this.cooldownUntilMs) {
+        const sleepMs = Math.min(this.cooldownUntilMs - now, 1000);
+        await this.sleep(sleepMs);
+        continue;
+      }
       this.refillTokens();
       if (this.tokens >= 1) {
         this.tokens -= 1;
         return;
       }
-      await new Promise((r) => setTimeout(r, 50));
+      await this.sleep(50);
     }
   }
 }

--- a/connector-registry/hubspot/v3/514-labs/typescript/data-api/tests/unit/rate-limit.adaptive.test.ts
+++ b/connector-registry/hubspot/v3/514-labs/typescript/data-api/tests/unit/rate-limit.adaptive.test.ts
@@ -1,0 +1,74 @@
+/* eslint-env jest */
+import { TokenBucketLimiter } from "../../src/rate-limit/token-bucket";
+
+function advanceTime(ms: number) {
+  jest.advanceTimersByTime(ms);
+  // Also tick real timers a tiny bit for promises resolution
+  return Promise.resolve();
+}
+
+describe("TokenBucketLimiter adaptive behavior", () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2020-01-01T00:00:00.000Z"));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it("respects Retry-After header by pausing issuance", async () => {
+    const limiter = new TokenBucketLimiter({ capacity: 2, refillPerSec: 10 });
+    // Consume current tokens
+    await limiter.waitForSlot();
+    await limiter.waitForSlot();
+
+    // Signal Retry-After of 3 seconds
+    limiter.updateFromResponse({ retryAfterSeconds: 3 });
+
+    const start = Date.now();
+    const promise = (async () => {
+      // Next wait should pause ~3s before allowing
+      const t0 = Date.now();
+      await limiter.waitForSlot();
+      return Date.now() - t0;
+    })();
+
+    await advanceTime(2000);
+    // Should still be waiting
+    let resolved = false;
+    promise.then(() => (resolved = true));
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    await advanceTime(1200);
+    const waitedMs = await promise;
+    expect(waitedMs).toBeGreaterThanOrEqual(2900);
+  });
+
+  it("pauses until reset when remaining=0 and reset is seconds-from-now", async () => {
+    const limiter = new TokenBucketLimiter({ capacity: 1, refillPerSec: 1 });
+    await limiter.waitForSlot();
+
+    limiter.updateFromResponse({ remaining: 0, reset: 2 }); // 2s cooldown
+
+    const p = limiter.waitForSlot();
+    await advanceTime(1500);
+    let done = false;
+    p.then(() => (done = true));
+    await Promise.resolve();
+    expect(done).toBe(false);
+
+    await advanceTime(600);
+    await p; // should resolve now
+    expect(true).toBe(true);
+  });
+
+  it("adjusts refill rate down when remaining fraction is low", async () => {
+    const limiter = new TokenBucketLimiter({ capacity: 10, refillPerSec: 10 });
+    limiter.updateFromResponse({ limit: 100, remaining: 5 }); // 5% remaining → heavy throttle
+    const status = limiter.getStatus();
+    expect(status.refillPerSec).toBeLessThan(10);
+  });
+});
+

--- a/pipeline-registry/hubspot-to-clickhouse/v3/514-labs/typescript/default/app/hubspot/docs/limits.md
+++ b/pipeline-registry/hubspot-to-clickhouse/v3/514-labs/typescript/default/app/hubspot/docs/limits.md
@@ -5,6 +5,10 @@ HubSpot enforces rate limits (vary by plan, object, and endpoint). This connecto
 - Token‑bucket rate limiting wraps all requests:
   - Configure with `rateLimit.requestsPerSecond`, `burstCapacity`, and `concurrentRequests`.
   - When configured (`requestsPerSecond > 0`), a `TokenBucketLimiter` waits for a slot before each request.
+  - When `rateLimit.adaptiveFromHeaders=true` (default), the limiter adapts to API feedback:
+    - Honors `Retry-After` by pausing issuance for the hinted duration
+    - If `remaining=0` and `reset` is present, pauses until reset time
+    - Gradually throttles when remaining/limit is low; returns to baseline otherwise
 
 - Retries with exponential backoff + jitter:
   - Defaults: `maxAttempts=3`, `initialDelayMs=1000`, `maxDelayMs=30000`, `backoffMultiplier=2`, `retryBudgetMs=60000`.

--- a/pipeline-registry/hubspot-to-clickhouse/v3/514-labs/typescript/default/app/hubspot/src/client/http-client.ts
+++ b/pipeline-registry/hubspot-to-clickhouse/v3/514-labs/typescript/default/app/hubspot/src/client/http-client.ts
@@ -18,6 +18,7 @@ export interface HttpRequestOptions {
 
 export interface HttpClientOptions {
   applyAuth?: (req: { headers: Record<string, string> }) => void;
+  onRateLimitSignal?: (info: { limit?: number; remaining?: number; reset?: number; retryAfterSeconds?: number }) => void;
 }
 
 export class HttpClient {
@@ -127,6 +128,10 @@ export class HttpClient {
           reset: Number(hdrs["x-hubspot-ratelimit-reset"]),
           retryAfterSeconds: Number.isFinite(retryAfter) ? retryAfter : undefined,
         };
+
+        try {
+          this.options.onRateLimitSignal?.(rateLimit);
+        } catch {}
 
         const envelope: HttpResponseEnvelope<T> = {
           data: data as T,

--- a/pipeline-registry/hubspot-to-clickhouse/v3/514-labs/typescript/default/app/hubspot/src/index.ts
+++ b/pipeline-registry/hubspot-to-clickhouse/v3/514-labs/typescript/default/app/hubspot/src/index.ts
@@ -42,6 +42,11 @@ export class HubSpotApiConnector implements HubSpotConnector {
           headers["Authorization"] = `Bearer ${token}`;
         }
       },
+      onRateLimitSignal: (info) => {
+        if (this.config?.rateLimit?.adaptiveFromHeaders && this.limiter) {
+          this.limiter.updateFromResponse(info);
+        }
+      },
     });
     const rps = this.config.rateLimit?.requestsPerSecond ?? 0;
     const capacity = this.config.rateLimit?.burstCapacity ?? rps;

--- a/pipeline-registry/hubspot-to-clickhouse/v3/514-labs/typescript/default/app/hubspot/src/rate-limit/token-bucket.ts
+++ b/pipeline-registry/hubspot-to-clickhouse/v3/514-labs/typescript/default/app/hubspot/src/rate-limit/token-bucket.ts
@@ -3,11 +3,14 @@ export class TokenBucketLimiter {
   private tokens: number;
   private refillPerSec: number;
   private lastRefill: number;
+  private baseRefillPerSec: number;
+  private cooldownUntilMs: number | undefined;
 
   constructor(params: { capacity: number; refillPerSec: number }) {
     this.capacity = Math.max(1, params.capacity);
     this.tokens = this.capacity;
     this.refillPerSec = Math.max(1, params.refillPerSec);
+    this.baseRefillPerSec = this.refillPerSec;
     this.lastRefill = Date.now();
   }
 
@@ -20,19 +23,81 @@ export class TokenBucketLimiter {
     this.lastRefill = now;
   }
 
+  private async sleep(ms: number) {
+    return new Promise((r) => setTimeout(r, ms));
+  }
+
+  private setCooldownFor(ms: number) {
+    const until = Date.now() + Math.max(0, ms);
+    if (!this.cooldownUntilMs || until > this.cooldownUntilMs) {
+      this.cooldownUntilMs = until;
+    }
+  }
+
+  updateFromResponse(info?: { limit?: number; remaining?: number; reset?: number; retryAfterSeconds?: number }): void {
+    if (!info) return;
+    if (Number.isFinite(info.retryAfterSeconds) && (info.retryAfterSeconds as number) > 0) {
+      const seconds = info.retryAfterSeconds as number;
+      this.setCooldownFor(seconds * 1000);
+      // eslint-disable-next-line no-console
+      console.info(`[rate-limit] Retry-After=${seconds}s → pausing new requests`);
+    }
+    const hasRemaining = info.remaining !== undefined && Number.isFinite(info.remaining as number);
+    const hasLimit = info.limit !== undefined && Number.isFinite(info.limit as number);
+    if (hasRemaining) {
+      const remaining = Math.max(0, info.remaining as number);
+      if (remaining <= 0 && info.reset !== undefined && Number.isFinite(info.reset as number)) {
+        const resetVal = info.reset as number;
+        const nowSec = Math.floor(Date.now() / 1000);
+        const msUntil = resetVal > nowSec ? Math.max(0, (resetVal - nowSec) * 1000) : Math.max(0, resetVal * 1000);
+        if (msUntil > 0) {
+          this.setCooldownFor(msUntil);
+          // eslint-disable-next-line no-console
+          console.info(`[rate-limit] Remaining=0, reset in ~${Math.ceil(msUntil / 1000)}s → pausing new requests`);
+        }
+      }
+      if (hasLimit) {
+        const limit = Math.max(1, info.limit as number);
+        const fraction = Math.min(1, Math.max(0, remaining / limit));
+        let factor = 1;
+        if (fraction <= 0.10) factor = 0.5;
+        else if (fraction <= 0.25) factor = 0.75;
+        else if (fraction <= 0.5) factor = 0.9;
+        else factor = 1.0;
+        const target = Math.max(1, Math.floor(this.baseRefillPerSec * factor));
+        if (target !== this.refillPerSec) {
+          this.refillPerSec = target;
+          // eslint-disable-next-line no-console
+          console.info(`[rate-limit] Adjusting pace → ${target}/s (remaining=${remaining}/${limit})`);
+        }
+      }
+    }
+  }
+
+  getStatus(): { capacity: number; tokens: number; refillPerSec: number; cooldownUntilMs?: number } {
+    return { capacity: this.capacity, tokens: this.tokens, refillPerSec: this.refillPerSec, cooldownUntilMs: this.cooldownUntilMs };
+  }
+
   canProceed(): boolean {
+    if (this.cooldownUntilMs && Date.now() < this.cooldownUntilMs) return false;
     this.refillTokens();
     return this.tokens >= 1;
   }
 
   async waitForSlot(): Promise<void> {
     while (true) {
+      const now = Date.now();
+      if (this.cooldownUntilMs && now < this.cooldownUntilMs) {
+        const sleepMs = Math.min(this.cooldownUntilMs - now, 1000);
+        await this.sleep(sleepMs);
+        continue;
+      }
       this.refillTokens();
       if (this.tokens >= 1) {
         this.tokens -= 1;
         return;
       }
-      await new Promise((r) => setTimeout(r, 50));
+      await this.sleep(50);
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,10 +275,6 @@ importers:
         specifier: ^5
         version: 5.8.3
 
-  connector-registry/google-analytics/v4/514-labs/typescript/data-api: {}
-
-  connector-registry/google-analytics/v4/tg339/typescript/data-api: {}
-
   connector-registry/hubspot/v3/514-labs/typescript/data-api:
     dependencies:
       zod:


### PR DESCRIPTION
Implement adaptive rate limiting for HubSpot connectors to automatically adjust request pacing based on API rate limit headers.

This enhancement allows the connector to dynamically slow down or pause requests when the API signals nearing limits (via `Retry-After`, `X-HubSpot-RateLimit-Remaining`, `X-HubSpot-RateLimit-Reset` headers), or to maintain a higher throughput when the quota is ample. This improves reliability by proactively avoiding 429 errors and optimizes performance by utilizing available quota more effectively.

---
<a href="https://cursor.com/background-agent?bcId=bc-38ab18f9-8c7a-438d-bb26-40cefbe2ad25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-38ab18f9-8c7a-438d-bb26-40cefbe2ad25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

