### PR TITLE
Run local connector tests

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,58 @@
+# Factory CLI — Local Connector Testing Harness
+
+Run and test connectors locally without a full pipeline or scheduler.
+
+## Install (workspace)
+
+- Ensure this package is included in your workspace (`pnpm-workspace.yaml`).
+- Build:
+
+```bash
+pnpm -w -C packages/cli build
+```
+
+Optionally link a bin:
+
+```bash
+pnpm -w -C packages/cli dev
+```
+
+## Usage
+
+```bash
+factory run-connector hubspot \
+  --implementation typescript/data-api \
+  --operation listContacts \
+  --params '{"limit":5,"properties":["firstname","lastname"]}' \
+  --limit 100 \
+  --output contacts.jsonl
+```
+
+- Provide config via `--config path/to/config.json` or env vars.
+- When no `--config` is provided, it will read `HUBSPOT_TOKEN` (or `API_TOKEN`).
+- Logs are enabled by default; disable with `--no-logs`.
+
+## Config
+
+Example `example.config.json`:
+
+```json
+{
+  "auth": { "type": "bearer", "bearer": { "token": "hs_pat_xxx" } },
+  "timeoutMs": 30000,
+  "rateLimit": { "requestsPerSecond": 5 }
+}
+```
+
+## Output
+
+- JSON Lines to stdout or a file via `--output`.
+- Streaming operations respect `--limit`.
+- On error, prints a JSON line with `error` containing `ConnectorError` fields when applicable.
+
+## Supported connectors
+
+- hubspot (typescript/data-api)
+
+Extend `dynamicImportConnector` in `src/runner.ts` to add more.
+

--- a/packages/cli/example.config.json
+++ b/packages/cli/example.config.json
@@ -1,0 +1,8 @@
+{
+  "auth": {
+    "type": "bearer",
+    "bearer": { "token": "hs_pat_xxx" }
+  },
+  "timeoutMs": 30000,
+  "rateLimit": { "requestsPerSecond": 5 }
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@workspace/factory-cli",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Local Connector Testing Harness CLI for running connectors in isolation",
+  "license": "MIT",
+  "type": "module",
+  "bin": {
+    "factory": "dist/bin/factory.js"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md",
+    "example.config.json"
+  ],
+  "scripts": {
+    "build": "tsup src/bin/factory.ts src/index.ts --format esm --external @workspace/connector-hubspot",
+    "dev": "node --enable-source-maps dist/bin/factory.js"
+  },
+  "dependencies": {
+    "commander": "^12.1.0",
+    "dotenv": "^16.4.5",
+    "zod": "^3.25.8",
+    "@workspace/connector-hubspot": "workspace:*"
+  },
+  "devDependencies": {
+    "tsup": "^8.2.4",
+    "typescript": "^5.6.3"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/cli/src/bin/factory.ts
+++ b/packages/cli/src/bin/factory.ts
@@ -33,7 +33,7 @@ program
     const { implementation, operation, config: configPath, params: paramsJson, limit, output, logs } = opts;
 
     const implParts = implementation.split("/");
-    if (implParts.length < 1) throw new Error("--implementation must be like 'typescript/data-api' or 'typescript'");
+    if (!implParts[0]) throw new Error("--implementation must be like 'typescript/data-api' or 'typescript'");
     const language = implParts[0];
 
     const params = paramsJson ? JSON.parse(paramsJson) : undefined;

--- a/packages/cli/src/bin/factory.ts
+++ b/packages/cli/src/bin/factory.ts
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+import { Command, InvalidArgumentError } from "commander";
+import path from "node:path";
+import fs from "node:fs";
+import process from "node:process";
+import { loadConfigFromFileOrEnv, type HarnessConfig } from "../config";
+import { runConnectorOperation } from "../runner";
+
+function parseInteger(value: string, prev: number | undefined): number {
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed < 0) throw new InvalidArgumentError("Must be a non-negative integer");
+  return parsed;
+}
+
+const program = new Command();
+program
+  .name("factory")
+  .description("Connector Factory CLI - Local Connector Testing Harness")
+  .version("0.1.0");
+
+program
+  .command("run-connector")
+  .description("Run a connector operation locally for debugging")
+  .argument("<connector>", "connector name (e.g., hubspot)")
+  .requiredOption("--implementation <impl>", "implementation to use (e.g., typescript/data-api)")
+  .requiredOption("--operation <name>", "operation to call (e.g., listContacts, streamDeals)")
+  .option("--config <path>", "path to JSON config file")
+  .option("--params <json>", "JSON string for operation params (e.g., '{\"limit\":5}')")
+  .option("--limit <n>", "limit number of items for streaming operations", parseInteger)
+  .option("--output <file>", "write JSONL output to a file instead of stdout")
+  .option("--no-logs", "disable verbose request/response logs")
+  .action(async (connectorName: string, opts: any) => {
+    const { implementation, operation, config: configPath, params: paramsJson, limit, output, logs } = opts;
+
+    const implParts = implementation.split("/");
+    if (implParts.length < 1) throw new Error("--implementation must be like 'typescript/data-api' or 'typescript'");
+    const language = implParts[0];
+
+    const params = paramsJson ? JSON.parse(paramsJson) : undefined;
+
+    const harnessConfig: HarnessConfig = await loadConfigFromFileOrEnv(configPath ?? null, {
+      connector: connectorName,
+      language,
+      implementation,
+      enableLogs: logs !== false,
+    });
+
+    const outputStream = output ? fs.createWriteStream(path.resolve(process.cwd(), output), { flags: "w" }) : process.stdout;
+
+    const resultCode = await runConnectorOperation({
+      connectorName,
+      language,
+      implementation,
+      operationName: operation,
+      params,
+      limit: typeof limit === "number" ? limit : undefined,
+      config: harnessConfig.connectorConfig,
+      output: outputStream,
+      enableLogs: harnessConfig.enableLogs,
+    });
+    if (output && outputStream !== process.stdout) outputStream.end();
+    process.exit(resultCode);
+  });
+
+program.parseAsync(process.argv);
+

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,0 +1,103 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import dotenv from "dotenv";
+import { z } from "zod";
+
+// Minimal mirror of ConnectorConfig to avoid importing the connector package directly here
+export type ConnectorConfig = {
+  baseUrl?: string;
+  timeoutMs?: number;
+  userAgent?: string;
+  defaultHeaders?: Record<string, string>;
+  defaultQueryParams?: Record<string, string | number | boolean>;
+  auth: { type: "bearer" | "oauth2"; bearer?: { token: string }; oauth2?: { clientId: string; clientSecret: string; refreshToken: string; accessToken?: string; expiresAt?: number; tokenUrl?: string } };
+  retry?: { maxAttempts?: number; initialDelayMs?: number; maxDelayMs?: number; backoffMultiplier?: number; retryableStatusCodes?: number[]; retryBudgetMs?: number; respectRetryAfter?: boolean };
+  rateLimit?: { requestsPerSecond?: number; concurrentRequests?: number; burstCapacity?: number; adaptiveFromHeaders?: boolean };
+  hooks?: any;
+};
+
+export type HarnessConfig = {
+  connector: string;
+  language: string;
+  implementation: string;
+  enableLogs: boolean;
+  connectorConfig: ConnectorConfig;
+};
+
+const FileConfigSchema = z.object({
+  baseUrl: z.string().optional(),
+  timeoutMs: z.number().optional(),
+  userAgent: z.string().optional(),
+  defaultHeaders: z.record(z.string()).optional(),
+  defaultQueryParams: z.record(z.union([z.string(), z.number(), z.boolean()])).optional(),
+  auth: z.union([
+    z.object({ type: z.literal("bearer"), bearer: z.object({ token: z.string() }) }),
+    z.object({
+      type: z.literal("oauth2"),
+      oauth2: z.object({
+        clientId: z.string(),
+        clientSecret: z.string(),
+        refreshToken: z.string(),
+        accessToken: z.string().optional(),
+        expiresAt: z.number().optional(),
+        tokenUrl: z.string().optional(),
+      }),
+    }),
+  ]),
+  retry: z
+    .object({
+      maxAttempts: z.number().optional(),
+      initialDelayMs: z.number().optional(),
+      maxDelayMs: z.number().optional(),
+      backoffMultiplier: z.number().optional(),
+      retryableStatusCodes: z.array(z.number()).optional(),
+      retryBudgetMs: z.number().optional(),
+      respectRetryAfter: z.boolean().optional(),
+    })
+    .optional(),
+  rateLimit: z
+    .object({
+      requestsPerSecond: z.number().optional(),
+      concurrentRequests: z.number().optional(),
+      burstCapacity: z.number().optional(),
+      adaptiveFromHeaders: z.boolean().optional(),
+    })
+    .optional(),
+});
+
+export async function loadConfigFromFileOrEnv(filePath: string | null, opts: { connector: string; language: string; implementation: string; enableLogs: boolean }): Promise<HarnessConfig> {
+  dotenv.config({ path: path.resolve(process.cwd(), ".env") });
+
+  let connectorConfig: ConnectorConfig | undefined;
+
+  if (filePath) {
+    const fullPath = path.resolve(process.cwd(), filePath);
+    const raw = await fs.readFile(fullPath, "utf8");
+    const parsed = JSON.parse(raw);
+    const cfg = FileConfigSchema.parse(parsed);
+    connectorConfig = cfg as unknown as ConnectorConfig;
+  }
+
+  if (!connectorConfig) {
+    // Map common env vars to a minimal ConnectorConfig
+    const token = process.env.HUBSPOT_TOKEN ?? process.env.API_TOKEN ?? process.env.TOKEN;
+    if (!token) {
+      throw new Error("No config file provided and no token found in environment (expected HUBSPOT_TOKEN or API_TOKEN)");
+    }
+    connectorConfig = {
+      auth: { type: "bearer", bearer: { token } },
+      timeoutMs: process.env.TIMEOUT_MS ? Number(process.env.TIMEOUT_MS) : undefined,
+      rateLimit: process.env.REQUESTS_PER_SECOND ? { requestsPerSecond: Number(process.env.REQUESTS_PER_SECOND) } : undefined,
+    };
+  }
+
+  return {
+    connector: opts.connector,
+    language: opts.language,
+    implementation: opts.implementation,
+    enableLogs: opts.enableLogs,
+    connectorConfig,
+  };
+}
+

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,3 @@
+export { loadConfigFromFileOrEnv } from "./config";
+export { runConnectorOperation } from "./runner";
+export type { HarnessConfig } from "./config";

--- a/packages/cli/src/runner.ts
+++ b/packages/cli/src/runner.ts
@@ -1,0 +1,148 @@
+import type { Writable } from "node:stream";
+import process from "node:process";
+import path from "node:path";
+import fs from "node:fs/promises";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { createDefaultLoggingHooks } from "./utils/logging";
+import type { ConnectorConfig } from "./config";
+
+type RunParams = {
+  connectorName: string;
+  language: string; // e.g., 'typescript'
+  implementation: string; // e.g., 'typescript/data-api'
+  operationName: string; // e.g., 'listContacts' | 'streamDeals'
+  params?: any;
+  limit?: number;
+  config: ConnectorConfig;
+  output: Writable;
+  enableLogs: boolean;
+};
+
+type GenericConnector = {
+  initialize(cfg: ConnectorConfig): Promise<void> | void;
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
+  [key: string]: any;
+};
+
+async function findRepoRoot(startDir: string): Promise<string> {
+  let current = startDir;
+  while (true) {
+    try {
+      const entries = await fs.readdir(current);
+      if (entries.includes("connector-registry") || entries.includes("pnpm-workspace.yaml")) return current;
+    } catch {}
+    const parent = path.dirname(current);
+    if (parent === current) return startDir; // fallback to start
+    current = parent;
+  }
+}
+
+async function resolveConnectorEntryFile(connector: string, language: string, implementation: string): Promise<string | null> {
+  if (language !== "typescript") return null;
+  const implParts = implementation.split("/");
+  const implDir = implParts.join(path.sep); // e.g., typescript/data-api
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const repoRoot = await findRepoRoot(here);
+  const registryRoot = path.join(repoRoot, "connector-registry", connector);
+  try {
+    const versionDirs = await fs.readdir(registryRoot, { withFileTypes: true });
+    for (const versionDir of versionDirs) {
+      if (!versionDir.isDirectory()) continue;
+      if (versionDir.name.startsWith("_")) continue;
+      const versionPath = path.join(registryRoot, versionDir.name);
+      const authorDirs = await fs.readdir(versionPath, { withFileTypes: true });
+      for (const authorDir of authorDirs) {
+        if (!authorDir.isDirectory()) continue;
+        if (authorDir.name.startsWith("_")) continue;
+        const candidate = path.join(versionPath, authorDir.name, implDir, "dist", "src", "index.js");
+        try {
+          await fs.access(candidate);
+          return candidate;
+        } catch {}
+      }
+    }
+  } catch {}
+  return null;
+}
+
+async function dynamicImportConnector(connector: string, language: string, implementation: string): Promise<{ create: () => GenericConnector }> {
+  // 1) Try workspace import first
+  try {
+    if (language === "typescript" && connector === "hubspot") {
+      const mod = await import("@workspace/connector-hubspot");
+      return { create: (mod as any).createHubSpotConnector };
+    }
+  } catch {}
+
+  // 2) Fallback: import via file path inside this monorepo
+  const entry = await resolveConnectorEntryFile(connector, language, implementation);
+  if (entry) {
+    const mod = await import(pathToFileURL(entry).toString());
+    // Heuristic: exported factory starts with create<PascalCase>Connector
+    const factory = Object.entries(mod).find(([k, v]) => k.startsWith("create") && typeof v === "function");
+    if (factory) return { create: factory[1] as any };
+  }
+  throw new Error(`Unsupported or unresolved connector: ${connector} (${language}/${implementation})`);
+}
+
+export async function runConnectorOperation(params: RunParams): Promise<number> {
+  const { connectorName, language, implementation, operationName, params: opParams, limit, config, output, enableLogs } = params;
+
+  const { create } = await dynamicImportConnector(connectorName, language, implementation);
+  const instance: GenericConnector = create();
+
+  const cfg: ConnectorConfig = { ...config };
+  if (enableLogs) {
+    const hooks = createDefaultLoggingHooks();
+    cfg.hooks = cfg.hooks ? { ...cfg.hooks, ...hooks } : hooks;
+  }
+
+  try {
+    instance.initialize(cfg as any);
+    await instance.connect();
+    if (typeof instance[operationName] !== "function") {
+      throw new Error(`Operation not found on connector: ${operationName}`);
+    }
+    const result = await instance[operationName](opParams ?? {});
+
+    // Stream vs paged
+    if (result && typeof (result as any)[Symbol.asyncIterator] === "function") {
+      let count = 0;
+      for await (const item of result as AsyncIterable<any>) {
+        output.write(`${JSON.stringify(item)}\n`);
+        count += 1;
+        if (typeof limit === "number" && count >= limit) break;
+      }
+    } else if (result && typeof result === "object" && "data" in result) {
+      output.write(`${JSON.stringify((result as any).data)}\n`);
+    } else {
+      output.write(`${JSON.stringify(result)}\n`);
+    }
+    await instance.disconnect();
+    return 0;
+  } catch (err: any) {
+    // Pretty-print ConnectorError if present
+    const connectorErr = err && err.name === "ConnectorError" ? err : null;
+    const errorOut = connectorErr
+      ? {
+          name: err.name,
+          message: err.message,
+          code: err.code,
+          statusCode: err.statusCode,
+          retryable: err.retryable,
+          details: err.details,
+          requestId: err.requestId,
+          source: err.source,
+        }
+      : { name: err?.name ?? "Error", message: String(err?.message ?? err) };
+    const line = JSON.stringify({ error: errorOut });
+    output.write(`${line}\n`);
+    if (process.env.DEBUG) console.error(err);
+    try {
+      await instance.disconnect();
+    } catch {}
+    return 1;
+  }
+}
+

--- a/packages/cli/src/utils/logging.ts
+++ b/packages/cli/src/utils/logging.ts
@@ -1,0 +1,47 @@
+import type { ConnectorConfig } from "../config";
+
+export function createDefaultLoggingHooks(): Required<NonNullable<ConnectorConfig["hooks"]>> {
+  const beforeRequest = [
+    {
+      name: "log-before-request",
+      priority: 1,
+      execute(ctx: any) {
+        const req = ctx.request ?? {};
+        const safeHeaders = { ...(req.headers ?? {}) };
+        if (safeHeaders.Authorization) safeHeaders.Authorization = "***";
+        console.error("[beforeRequest]", ctx.operation ?? "", { method: req.method, url: req.url, headers: safeHeaders, body: req.body });
+      },
+    },
+  ];
+  const afterResponse = [
+    {
+      name: "log-after-response",
+      priority: 1,
+      execute(ctx: any) {
+        const resp = ctx.response ?? {};
+        console.error("[afterResponse]", ctx.operation ?? "", { status: resp.status, meta: resp.meta });
+      },
+    },
+  ];
+  const onError = [
+    {
+      name: "log-on-error",
+      priority: 1,
+      execute(ctx: any) {
+        console.error("[onError]", ctx.operation ?? "", ctx.error);
+      },
+    },
+  ];
+  const onRetry = [
+    {
+      name: "log-on-retry",
+      priority: 1,
+      execute(ctx: any) {
+        console.error("[onRetry]", ctx.metadata);
+      },
+    },
+  ];
+
+  return { beforeRequest, afterResponse, onError, onRetry } as any;
+}
+

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["es2022"],
+    "outDir": "dist",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "declaration": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,10 +275,6 @@ importers:
         specifier: ^5
         version: 5.8.3
 
-  connector-registry/google-analytics/v4/514-labs/typescript/data-api: {}
-
-  connector-registry/google-analytics/v4/tg339/typescript/data-api: {}
-
   connector-registry/hubspot/v3/514-labs/typescript/data-api:
     dependencies:
       zod:
@@ -307,6 +303,28 @@ importers:
         specifier: ^5.6.3
         version: 5.8.3
 
+  packages/cli:
+    dependencies:
+      '@workspace/connector-hubspot':
+        specifier: workspace:*
+        version: link:../../connector-registry/hubspot/v3/514-labs/typescript/data-api
+      commander:
+        specifier: ^12.1.0
+        version: 12.1.0
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.6.1
+      zod:
+        specifier: ^3.25.8
+        version: 3.25.76
+    devDependencies:
+      tsup:
+        specifier: ^8.2.4
+        version: 8.5.0(@swc/core@1.13.3(@swc/helpers@0.5.17))(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.4)(typescript@5.8.3)
+      typescript:
+        specifier: ^5.6.3
+        version: 5.8.3
+
   packages/eslint-config:
     dependencies:
       '@eslint/js':
@@ -329,7 +347,7 @@ importers:
     dependencies:
       '@514labs/moose-lib':
         specifier: latest
-        version: 0.5.23(@swc/core@1.13.3(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)(@types/node@24.2.0)(ts-patch@3.3.0)(typia@9.7.1(typescript@5.8.3))
+        version: 0.6.21(@swc/core@1.13.3(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)(@types/node@24.2.0)(ts-patch@3.3.0)(typia@9.7.1(typescript@5.8.3))
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -595,7 +613,7 @@ importers:
     dependencies:
       '@514labs/moose-lib':
         specifier: latest
-        version: 0.5.29(@swc/core@1.13.3(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)(@types/node@24.2.0)(ts-patch@3.3.0)(typia@9.7.1(typescript@5.8.3))
+        version: 0.6.21(@swc/core@1.13.3(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)(@types/node@24.2.0)(ts-patch@3.3.0)(typia@9.7.1(typescript@5.8.3))
       dotenv:
         specifier: ^16.4.5
         version: 16.6.1
@@ -605,7 +623,7 @@ importers:
     devDependencies:
       '@514labs/moose-cli':
         specifier: latest
-        version: 0.5.29
+        version: 0.6.21
       tsup:
         specifier: ^8.0.0
         version: 8.5.0(@swc/core@1.13.3(@swc/helpers@0.5.17))(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.4)(typescript@5.8.3)
@@ -646,43 +664,36 @@ importers:
 
 packages:
 
-  '@514labs/moose-cli-darwin-arm64@0.5.29':
-    resolution: {integrity: sha512-BX1AMotyskdYLIJD5AyTXX1hiOU3lW2fBtUspsnrOKzfkj1kHepXTNPdwv9qC58BepH7Qm3/akZo3D25qrKsQA==}
+  '@514labs/moose-cli-darwin-arm64@0.6.21':
+    resolution: {integrity: sha512-DA8+21fOtLIdJ9xwC+/j4iU3XYRnzsYrFbXm7rf0mPxa3jFtbv0o0iPiBoFrRYGKbirURmxQEnNl6+bonkZjnQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@514labs/moose-cli-darwin-x64@0.5.29':
-    resolution: {integrity: sha512-B3VWE+gMLlpkLrsB4hwdfSMb60dQMY0UBo4urL5orhanYqxWSAWSNdg4cIXMkWbWV+D29/1LSNjHu1xjulcEqw==}
+  '@514labs/moose-cli-darwin-x64@0.6.21':
+    resolution: {integrity: sha512-3N0LQlzh/AlWEFyW976pK+XMBv8YBJ4xKExLAlO6UaJVKQTgvbkutEtozPZKjndo8r2w0PKYe/8T3kAx4M8DLg==}
     cpu: [x64]
     os: [darwin]
 
-  '@514labs/moose-cli-linux-arm64@0.5.29':
-    resolution: {integrity: sha512-lPCMWse9PpGns7vGPjy7wny7a+xjGkhYWbidI0+l2iFOHTez8l3TKXllR7OgdFdlSy84eW3aIF8aXAhQLQOPYQ==}
+  '@514labs/moose-cli-linux-arm64@0.6.21':
+    resolution: {integrity: sha512-zYaR/AavptMVd0U6lCLo50p3Spsj+Jv01eBSiNJKqB8wJ2Ri/3MvKPQzYiSS8ApXBQMvorEgTrDzL7HwJTBr3A==}
     cpu: [arm64]
     os: [linux]
 
-  '@514labs/moose-cli-linux-x64@0.5.29':
-    resolution: {integrity: sha512-uyZxywGdO6+qr0j+Z2b8mR8Ayo0ArBb4ujcyNt7YCIp33QAsU0UEEYep3KEtQXfddC28baHeCfC+dmATdNtyKg==}
+  '@514labs/moose-cli-linux-x64@0.6.21':
+    resolution: {integrity: sha512-rkCRWoKkG5iD6dKdjiDNh5NaI6Hc+RL/G5ZgRbEvwLYXimXZPOfPU3Bt0E5oQEIPCigy/Olm9qPPf7eWpqhrwA==}
     cpu: [x64]
     os: [linux]
 
-  '@514labs/moose-cli@0.5.29':
-    resolution: {integrity: sha512-/9KZ5J6Q4SnYUBnN0ZUpDiYIRjJPHVGIHArVwF1BX14xcjuozf15OBL9XI8XQYdnxRHi4zqRHWl3MZQOFwjyUA==}
+  '@514labs/moose-cli@0.6.21':
+    resolution: {integrity: sha512-upPTVIGxFaeE2c1C109Ri82og4LZfsE9WYwrEkh9OEUB+zR9eiOEayv4xjvGHT1SjD0hihtYt1HlfzrAykA9eg==}
     hasBin: true
 
-  '@514labs/moose-lib@0.5.23':
-    resolution: {integrity: sha512-B6peQMfJ7BefgGAUFIsZ3s2Jsa9H1AUNJv+4moH39p3iCUNpnU84aTMsw/qC+ARadFTNE6V2zjk82EmG+EABEA==}
+  '@514labs/moose-lib@0.6.21':
+    resolution: {integrity: sha512-mC10a4dxxSkV5K/If1h3SrDXt1pPmFWB2kjuxji0qQ5+4d+df8shoWqy6NsHBJPgjEEwfqR2Ip/rkLU4JiFUwQ==}
     hasBin: true
     peerDependencies:
       ts-patch: ^3.3.0
-      typia: ^7.6.0
-
-  '@514labs/moose-lib@0.5.29':
-    resolution: {integrity: sha512-TeWmWoVT+5SzqsqU8YQgQMAhS7laRm+qjyWpcTisF4vU3D32nK3EPL9P4ydnbh0iSGDmbm1L1Mm6PPL6GG118Q==}
-    hasBin: true
-    peerDependencies:
-      ts-patch: ^3.3.0
-      typia: ^7.6.0
+      typia: ^9.6.1
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -3886,6 +3897,10 @@ packages:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
 
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
+
   commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
     engines: {node: '>=18'}
@@ -6591,6 +6606,7 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
@@ -7054,11 +7070,6 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
-  typescript@5.7.3:
-    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
@@ -7444,26 +7455,26 @@ packages:
 
 snapshots:
 
-  '@514labs/moose-cli-darwin-arm64@0.5.29':
+  '@514labs/moose-cli-darwin-arm64@0.6.21':
     optional: true
 
-  '@514labs/moose-cli-darwin-x64@0.5.29':
+  '@514labs/moose-cli-darwin-x64@0.6.21':
     optional: true
 
-  '@514labs/moose-cli-linux-arm64@0.5.29':
+  '@514labs/moose-cli-linux-arm64@0.6.21':
     optional: true
 
-  '@514labs/moose-cli-linux-x64@0.5.29':
+  '@514labs/moose-cli-linux-x64@0.6.21':
     optional: true
 
-  '@514labs/moose-cli@0.5.29':
+  '@514labs/moose-cli@0.6.21':
     optionalDependencies:
-      '@514labs/moose-cli-darwin-arm64': 0.5.29
-      '@514labs/moose-cli-darwin-x64': 0.5.29
-      '@514labs/moose-cli-linux-arm64': 0.5.29
-      '@514labs/moose-cli-linux-x64': 0.5.29
+      '@514labs/moose-cli-darwin-arm64': 0.6.21
+      '@514labs/moose-cli-darwin-x64': 0.6.21
+      '@514labs/moose-cli-linux-arm64': 0.6.21
+      '@514labs/moose-cli-linux-x64': 0.6.21
 
-  '@514labs/moose-lib@0.5.23(@swc/core@1.13.3(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)(@types/node@24.2.0)(ts-patch@3.3.0)(typia@9.7.1(typescript@5.8.3))':
+  '@514labs/moose-lib@0.6.21(@swc/core@1.13.3(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)(@types/node@24.2.0)(ts-patch@3.3.0)(typia@9.7.1(typescript@5.8.3))':
     dependencies:
       '@clickhouse/client': 1.8.1
       '@clickhouse/client-web': 1.5.0
@@ -7479,38 +7490,9 @@ snapshots:
       kafkajs: 2.2.4
       redis: 4.7.1
       toml: 3.0.0
-      ts-node: 10.9.2(@swc/core@1.13.3(@swc/helpers@0.5.17))(@types/node@24.2.0)(typescript@5.7.3)
+      ts-node: 10.9.2(@swc/core@1.13.3(@swc/helpers@0.5.17))(@types/node@24.2.0)(typescript@5.9.2)
       ts-patch: 3.3.0
-      typescript: 5.7.3
-      typia: 9.7.1(typescript@5.8.3)
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/helpers'
-      - '@swc/wasm'
-      - '@types/node'
-      - esbuild
-      - uglify-js
-      - webpack-cli
-
-  '@514labs/moose-lib@0.5.29(@swc/core@1.13.3(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)(@types/node@24.2.0)(ts-patch@3.3.0)(typia@9.7.1(typescript@5.8.3))':
-    dependencies:
-      '@clickhouse/client': 1.8.1
-      '@clickhouse/client-web': 1.5.0
-      '@temporalio/activity': 1.12.1
-      '@temporalio/client': 1.12.1
-      '@temporalio/common': 1.12.1
-      '@temporalio/worker': 1.12.1(@swc/helpers@0.5.17)
-      '@temporalio/workflow': 1.12.1
-      commander: 13.1.0
-      csv-parse: 5.6.0
-      fastq: 1.17.1
-      jose: 5.9.2
-      kafkajs: 2.2.4
-      redis: 4.7.1
-      toml: 3.0.0
-      ts-node: 10.9.2(@swc/core@1.13.3(@swc/helpers@0.5.17))(@types/node@24.2.0)(typescript@5.7.3)
-      ts-patch: 3.3.0
-      typescript: 5.7.3
+      typescript: 5.9.2
       typia: 9.7.1(typescript@5.8.3)
     transitivePeerDependencies:
       - '@swc/core'
@@ -10920,6 +10902,8 @@ snapshots:
 
   commander@10.0.1: {}
 
+  commander@12.1.0: {}
+
   commander@13.1.0: {}
 
   commander@2.20.3: {}
@@ -11410,8 +11394,8 @@ snapshots:
       '@typescript-eslint/parser': 8.39.0(eslint@8.57.1)(typescript@5.8.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -11434,7 +11418,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.1
@@ -11445,7 +11429,7 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11456,11 +11440,11 @@ snapshots:
       '@typescript-eslint/parser': 8.39.0(eslint@8.57.1)(typescript@5.8.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -14852,26 +14836,6 @@ snapshots:
       '@swc/core': 1.13.3(@swc/helpers@0.5.17)
     optional: true
 
-  ts-node@10.9.2(@swc/core@1.13.3(@swc/helpers@0.5.17))(@types/node@24.2.0)(typescript@5.7.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 24.2.0
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.7.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.13.3(@swc/helpers@0.5.17)
-
   ts-node@10.9.2(@swc/core@1.13.3(@swc/helpers@0.5.17))(@types/node@24.2.0)(typescript@5.8.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -14887,6 +14851,26 @@ snapshots:
       diff: 4.0.2
       make-error: 1.3.6
       typescript: 5.8.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.13.3(@swc/helpers@0.5.17)
+
+  ts-node@10.9.2(@swc/core@1.13.3(@swc/helpers@0.5.17))(@types/node@24.2.0)(typescript@5.9.2):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 24.2.0
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.9.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
@@ -15027,8 +15011,6 @@ snapshots:
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
-
-  typescript@5.7.3: {}
 
   typescript@5.8.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,4 @@ packages:
   - "connector-registry/**"
   - "packages/*"
   - "pipeline-registry/**"
+  - "packages/cli"


### PR DESCRIPTION
Add a `factory` CLI with a `run-connector` command to provide a local connector testing harness for isolated debugging and development.

This tool allows developers to execute connector extraction logic locally without setting up a full pipeline or external scheduler. It significantly improves developer ergonomics by enabling quick reproduction of issues and easy verification of connector implementations against live APIs.

---
<a href="https://cursor.com/background-agent?bcId=bc-d6a200f2-b3a8-4318-be8a-2e2b290691d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d6a200f2-b3a8-4318-be8a-2e2b290691d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

