### PR TITLE
Rename factory-cli to registry and update package configuration

### DIFF
--- a/packages/factory-cli/package.json
+++ b/packages/factory-cli/package.json
@@ -1,16 +1,23 @@
 {
-  "name": "@workspace/factory-cli",
+  "name": "@514-labs/registry",
   "version": "0.1.0",
-  "private": true,
+  "private": false,
   "type": "module",
   "bin": {
-    "factory": "dist/index.js"
+    "registry": "dist/index.js"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs --dts",
-    "dev": "tsup src/index.ts --watch --format esm,cjs --dts"
+    "dev": "tsup src/index.ts --watch --format esm,cjs --dts",
+    "prepublishOnly": "pnpm build"
   },
   "dependencies": {
     "commander": "^12.1.0",

--- a/packages/factory-cli/src/index.ts
+++ b/packages/factory-cli/src/index.ts
@@ -5,8 +5,8 @@ import { runScaffold } from './scaffold'
 
 const program = new Command()
 program
-  .name('factory')
-  .description('Connector & Pipeline Factory CLI')
+  .name('registry')
+  .description('514 Labs Registry CLI')
   .version(pkg.version)
 
 // Ensure parsing/validation errors cause non-zero exit codes when awaited


### PR DESCRIPTION
Prep for public access. Enhance CLI description and add prepublish script for build automation.